### PR TITLE
Fix Podspec

### DIFF
--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -24,10 +24,6 @@ Pod::Spec.new do |s|
     unzip -o Approov.xcframework.zip
     rm -f Approov.xcframework.zip
   CMD
-  
-  # Approov dependency - pulling the binary from GitHub release
-  ## Should be removed and not be a direct dependency
-  #s.dependency "Approov", "~> 3.2.4"  # Specify the version here if a podspec exists
 
   # Pod target xcconfig settings if required
   s.pod_target_xcconfig = {

--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "Sources/ApproovURLSession/**/*.{swift,h}"
 
   # Vendored frameworks for both iOS and watchOS
-  s.vendored_frameworks = Approov.xcframework'
+  s.vendored_frameworks = 'Approov.xcframework'
   s.prepare_command = <<-CMD
     curl -L https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip > Approov.xcframework.zip
     unzip -o Approov.xcframework.zip

--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -18,9 +18,9 @@ Pod::Spec.new do |s|
   s.source_files = "Sources/ApproovURLSession/**/*.{swift,h}"
 
   # Vendored frameworks for both iOS and watchOS
-  s.vendored_frameworks = 'https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip'
+  s.vendored_frameworks = Approov.xcframework'
   s.prepare_command = <<-CMD
-    curl -L https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip
+    curl -L https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip > Approov.xcframework.zip
     unzip -o Approov.xcframework.zip
     rm -f Approov.xcframework.zip
   CMD

--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -18,10 +18,16 @@ Pod::Spec.new do |s|
   s.source_files = "Sources/ApproovURLSession/**/*.{swift,h}"
 
   # Vendored frameworks for both iOS and watchOS
-  #s.vendored_frameworks = 'https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip'
-
+  s.vendored_frameworks = 'https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip'
+  s.prepare_command = <<-CMD
+    curl -L https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip
+    unzip -o Approov.xcframework.zip
+    rm -f Approov.xcframework.zip
+  CMD
+  
   # Approov dependency - pulling the binary from GitHub release
-  s.dependency "Approov", "~> 3.2.4"  # Specify the version here if a podspec exists
+  ## Should be removed and not be a direct dependency
+  #s.dependency "Approov", "~> 3.2.4"  # Specify the version here if a podspec exists
 
   # Pod target xcconfig settings if required
   s.pod_target_xcconfig = {

--- a/Podspec
+++ b/Podspec
@@ -16,9 +16,6 @@ Pod::Spec.new do |s|
 
   # Specify the source code paths for the combined target
   s.source_files = "Sources/ApproovURLSession/**/*.{swift,h}"
-
-  # Approov dependency - pulling the binary from GitHub release
-  s.dependency "Approov"
   
   s.watchos.vendored_frameworks = 'https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip'
   s.ios.vendored_frameworks = 'https://github.com/approov/approov-ios-sdk/releases/download/3.2.4/Approov.xcframework.zip'


### PR DESCRIPTION
Couldn't integrate on a project, because Approov itself isn't a pod but a framework downloaded as binary.
Remove the Approov dependency and added extract command .

Also could the Podspec file be deleted?
It seems to only fetch the $name.podspec file when adding this as a dependency.