### PR TITLE
Feature/ignore user unhandled auth

### DIFF
--- a/ApproovURLSession/3.3.2/ApproovURLSession.podspec
+++ b/ApproovURLSession/3.3.2/ApproovURLSession.podspec
@@ -1,0 +1,32 @@
+Pod::Spec.new do |s|
+  s.name         = "ApproovURLSession"
+  s.version      = "3.3.2"
+  s.summary      = "Approov mobile attestation SDK"
+  s.description  = <<-DESC
+    Approov SDK integrates security attestation and secure string fetching for both iOS and watchOS apps.
+  DESC
+  s.homepage     = "https://approov.io"
+  s.license      = { type: "Commercial", file: "LICENSE" }
+  s.authors      = { "CriticalBlue, Ltd." => "support@approov.io" }
+  s.source       = { git: "https://github.com/approov/approov-service-urlsession.git", tag: s.version }
+
+  # Supported platforms
+  s.ios.deployment_target = '12.0'
+  s.watchos.deployment_target = '7.0'
+
+  # Specify the source code paths for the combined target
+  s.source_files = 'Sources/ApproovURLSession/**/*'
+
+  # Vendored frameworks for both iOS and watchOS
+  s.vendored_frameworks = 'Approov.xcframework'
+  s.prepare_command = <<-CMD
+    curl -L https://github.com/approov/approov-ios-sdk/releases/download/3.3.0/Approov.xcframework.zip > Approov.xcframework.zip
+    unzip -o Approov.xcframework.zip
+    rm -f Approov.xcframework.zip
+  CMD
+
+  # Pod target xcconfig settings if required
+  s.pod_target_xcconfig = {
+    'VALID_ARCHS' => 'arm64 x86_64 arm64_32 x86_64'  # Combine valid architectures
+  }
+end

--- a/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
+++ b/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
@@ -159,8 +159,14 @@ class PinningURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDel
     func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         if let delegate = optionalURLDelegate as? URLSessionTaskDelegate {
             if !challenge.protectionSpace.authenticationMethod.isEqual(NSURLAuthenticationMethodServerTrust) {
-                // delegate any challenge that is not to do with pinning
-                delegate.urlSession?(session, task: task, didReceive: challenge, completionHandler: completionHandler)
+                if let userDelegate = optionalURLDelegate {
+                    // delegate any challenge that is not to do with pinning
+                    userDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+                }
+                else {
+                    // the user is not providing a delegate so we need to invoke the completion handler since we only deal with certificate pinning
+                    completionHandler(.useCredential, nil)
+                }
             }
             else {
                 // we have a server trust challenge

--- a/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
+++ b/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
@@ -119,8 +119,14 @@ class PinningURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDel
      */
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         if !challenge.protectionSpace.authenticationMethod.isEqual(NSURLAuthenticationMethodServerTrust) {
-            // delegate any challenge that is not to do with pinning
-            optionalURLDelegate?.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+            if let userDelegate = optionalURLDelegate {
+                // delegate any challenge that is not to do with pinning
+                userDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+            }
+            else {
+                // the user is not providing a delegate so we need to invoke the completion handler since we only deal with certificate pinning
+                completionHandler(.useCredential, nil)
+            }
         }
         else {
             // we have a server trust challenge


### PR DESCRIPTION
If the type of authentication is different than server certificate and the user does not need to handle it, invoke the completion handler and accept the challenge as success. This is needed so the MISUSE_API is not triggered by not invoking a completion handler in those cases.