### PR TITLE
Proceed when request for token fetch fails

### DIFF
--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -656,7 +656,9 @@ public class ApproovService {
         }
 
         // we construct a response to return
-        var response = ApproovUpdateResponse(request: request, decision: .ShouldFail, sdkMessage: "", error: nil)
+        // by default, when proceedOnNetworkFail is false, we will not proceed with the request and propagate the failure to the client
+        // if proceedOnNetworkFail is true, we will proceed with the request but without the Approov token header
+        var response = ApproovUpdateResponse(request: request, decision: proceedOnNetworkFail ? .ShouldProceed : .ShouldFail, sdkMessage: "", error: nil)
 
         // get all of the headers including those from the session configuration
         var allHeaders: [String: String] = Dictionary()


### PR DESCRIPTION
According to documentation `proceedOnNetworkFail` flag enables network interceptor to _proceed anyway if it is not possible to obtain an Approov token due to a networking failure_. However, the current implementation propagates an error state with nil error to the client instead. 

Steps to reproduce: 
1. Imitate MitM or a bad connection. (I tested this with Proxyman by enabling and disabling SSL exclusions)
2. Perform a request. 

Expected result:
1. Approov token fetch fails. 
2. The original request is performed without a token.

Actual result:
1. Approov token fetch fails. 
2. The original request was not performed at all. 

From my investigation, the problem is that when `proceedOnNetworkFail ` is set to true, the logic will propagate the default response set on line 659. The decision is set to `.ShouldFail` and never changes to `.ShouldProceed`. 

I tested the implementation with the changes in this PR and I'm getting the expected behaviour where in case the token cannot be fetched, the request is performed without it. When token is fetched, the request has the token appended. 

I attempted to add unit tests to cover this case, but struggled with the binary target. It appears that it needs to be signed to proceed. I'm happy to adjust the solution if I've missed anything. 