### PR TITLE
Feature/simplify-init

### DIFF
--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ApproovURLSession"
-  s.version      = "3.5.8"
+  s.version      = "3.5.9"
   s.summary      = "Approov mobile attestation SDK"
   s.description  = <<-DESC
     Approov SDK integrates security attestation and secure string fetching for both iOS and watchOS apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [3.5.9] - 2026-06-02
+
+### Changed
+- Simplified `initialize`. The ObjC/Swift interop behavior is preserved: the Approov SDK's ObjC `BOOL` return of `NO` without an `NSError` is bridged by Swift as `Foundation._GenericObjCError` code 0 — this is the "already initialized" signal (equivalent to a `false` boolean return on Android) and is logged without being re-thrown. Any other error is a genuine failure and is still surfaced as an `ApproovError.initializationFailure`. State is only reset after the SDK confirms success, so a failure preserves the prior operating mode.
+
 ## [3.5.8] - 2026-04-09
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Approov Integration Examples
+Copyright (c) 2021-2026 Approov Integration Examples
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import Foundation
 import PackageDescription
 // The release tag for this version of ApproovURLSession
-let releaseTAG = "3.5.8"
+let releaseTAG = "3.5.9"
 // SDK package version (used for both iOS and watchOS)
 let sdkVersion: Version = "3.5.3"
 let useMiniSDK = ProcessInfo.processInfo.environment["APPROOV_USE_MINI_SDK"] == "1"

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ The `ApproovService` functions may throw specific errors to provide additional i
 * `rejectionError` an attestation has been rejected, the `ARC` and `rejectionReasons` may contain specific device information that would help troubleshooting
 * `networkingError` generally can be retried since it can be temporary network issue
 * `pinningError` is a certificate error
-* `configurationError` a configuration feature is disabled or wrongly configured (i.e. attempting to initialize with different config from a previous instantiation) 
-* `initializationFailure` the ApproovService failed to be initialized (subsequent network requests will not be performed)
+* `configurationError` a configuration feature is disabled or wrongly configured
+* `initializationFailure` the ApproovService failed to be initialized, such as when attempting to initialize with a different configuration from a previous instantiation (subsequent network requests will not be performed)
 
 Example error handling:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ The `ApproovService` functions may throw specific errors to provide additional i
 * `configurationError` a configuration feature is disabled or wrongly configured (i.e. attempting to initialize with different config from a previous instantiation) 
 * `initializationFailure` the ApproovService failed to be initialized (subsequent network requests will not be performed)
 
+Example error handling:
+
+```swift
+if let approovError = error as? ApproovError {
+    switch approovError {
+    case .networkingError(let message):
+        // Temporary network issue: can retry
+        print("Retryable networking error: \(message)")
+        
+    case .rejectionError(let message, let ARC, let rejectionReasons):
+        // Attestation rejected: device is untrusted (e.g. secure strings unavailable for this device)
+        print("Rejected. ARC: \(ARC), Reasons: \(rejectionReasons)")
+        
+    case .pinningError(let message):
+        // TLS Pinning/Certificate verification failed
+        print("Pinning error: \(message)")
+        
+    case .permanentError(let message):
+        // Permanent failure (e.g. service not initialized)
+        print("Permanent error: \(message)")
+        
+    default:
+        break
+    }
+}
+```
+
+
 ## CHECKING IT WORKS
 Initially you won't have set which API domains to protect, so the interceptor will not add anything. It will have called Approov though and made contact with the Approov cloud service. You will see logging from Approov saying `unknown URL`.
 
@@ -45,9 +73,9 @@ Your Approov onboarding email should contain a link allowing you to access [Live
 ## NEXT STEPS
 To actually protect your APIs and/or secrets there are some further steps. Approov provides two different options for protection:
 
-* [API PROTECTION](https://github.com/approov/quickstart-ios-swift-urlsession/blob/master/API-PROTECTION.md): You should use this if you control the backend API(s) being protected and are able to modify them to ensure that a valid Approov token is being passed by the app. An [Approov Token](https://approov.io/docs/latest/approov-usage-documentation/#approov-tokens) is short lived cryptographically signed JWT proving the authenticity of the call.
+* **API PROTECTION** You should use this if you control the backend API(s) being protected and are able to modify them to ensure that a valid Approov token is being passed by the app. An [Approov Token](https://approov.io/docs/latest/approov-usage-documentation/#approov-tokens) is short lived cryptographically signed JWT proving the authenticity of the call.
 
-* [SECRETS PROTECTION](https://github.com/approov/quickstart-ios-swift-urlsession/blob/master/SECRETS-PROTECTION.md): This allows app secrets, including API keys for 3rd party services, to be protected so that they no longer need to be included in the released app code. These secrets are only made available to valid apps at runtime.
+* **SECRETS PROTECTION** This allows app secrets, including API keys for 3rd party services, to be protected so that they no longer need to be included in the released app code. These secrets are only made available to valid apps at runtime.
 
 Note that it is possible to use both approaches side-by-side in the same app.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@ A wrapper for the [Approov SDK](https://github.com/approov/approov-ios-sdk) to e
 Please see the [Quickstart](https://github.com/approov/quickstart-ios-swift-urlsession) for example integration.
 
 ## ADDING APPROOV SERVICE DEPENDENCY
-The Approov integration is available via the [`Swift Package Manager`](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app). This allows inclusion into the project by simply specifying a dependency in the `File -> Add Packages...` Xcode option if the project is selected:
+The Approov integration is available via the [`Swift Package Manager`](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app). This allows inclusion into the project by specifying a dependency in the `File -> Add Packages...` Xcode option.
 
-![Add Package Dependency](https://raw.githubusercontent.com/approov/quickstart-ios-swift-urlsession/master/readme-images/AddPackage.png)
-
-Enter the repository `https://github.com/approov/approov-service-urlsession.git` into the search box. You will then have to select the relevant version you wish to use. To do so, select the `Exact Version` option and enter a specific option you require or use the latest available `tag`, which should be selected for you.
+Enter the repository `https://github.com/approov/approov-service-urlsession.git` into the search box and latest available version will be automatically selected for you.
 
 Once you click `Add Package` the last step will confirm the package product and target selection. The `approov-service-urlsession` is actually an open source wrapper layer that allows you to easily use Approov with `URLSession`. This has a further dependency to the closed source [Approov SDK](https://github.com/approov/approov-ios-sdk).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The `ApproovURLSession` class mimics the interface of the `URLSession` class pro
 ```swift
 import ApproovURLSessionPackage
 
-try! ApproovService.initialize("<enter-your-config-string-here>")
+try! ApproovService.initialize(config: "<enter-your-config-string-here>")
 let session = ApproovURLSession(URLSessionConfiguration.default)
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Please see the [Quickstart](https://github.com/approov/quickstart-ios-swift-urls
 ## ADDING APPROOV SERVICE DEPENDENCY
 The Approov integration is available via the [`Swift Package Manager`](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app). This allows inclusion into the project by simply specifying a dependency in the `File -> Add Packages...` Xcode option if the project is selected:
 
-![Add Package Dependency](readme-images/AddPackage.png)
+![Add Package Dependency](https://raw.githubusercontent.com/approov/quickstart-ios-swift-urlsession/master/readme-images/AddPackage.png)
 
 Enter the repository `https://github.com/approov/approov-service-urlsession.git` into the search box. You will then have to select the relevant version you wish to use. To do so, select the `Exact Version` option and enter a specific option you require or use the latest available `tag`, which should be selected for you.
 
 Once you click `Add Package` the last step will confirm the package product and target selection. The `approov-service-urlsession` is actually an open source wrapper layer that allows you to easily use Approov with `URLSession`. This has a further dependency to the closed source [Approov SDK](https://github.com/approov/approov-ios-sdk).
 
-Alternatively, use `cocoapods` and add the package dependencies similar to how they are used in the example `shapes-app/Podfile` in the [Quickstart](https://github.com/approov/quickstart-ios-swift-urlsession) repository.
+Alternatively, use `cocoapods` and add the package dependencies similar to how they are used in the example [`shapes-app/Podfile`](https://github.com/approov/quickstart-ios-swift-urlsession/blob/master/shapes-app/Podfile) in the [Quickstart](https://github.com/approov/quickstart-ios-swift-urlsession) repository.
 
 ## USING APPROOV SERVICE
 The `ApproovURLSession` class mimics the interface of the `URLSession` class provided by Apple but includes an additional Approov attestation calls. The simplest way to use the `ApproovURLSession` class is to find and replace all the `URLSession` construction calls with `ApproovURLSession`. 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,76 @@ A wrapper for the [Approov SDK](https://github.com/approov/approov-ios-sdk) to e
 
 Please see the [Quickstart](https://github.com/approov/quickstart-ios-swift-urlsession) for example integration.
 
-## Swift Package Manager Import
+## ADDING APPROOV SERVICE DEPENDENCY
+The Approov integration is available via the [`Swift Package Manager`](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app). This allows inclusion into the project by simply specifying a dependency in the `File -> Add Packages...` Xcode option if the project is selected:
 
-When adding this package with Swift Package Manager, import the module as:
+![Add Package Dependency](readme-images/AddPackage.png)
+
+Enter the repository `https://github.com/approov/approov-service-urlsession.git` into the search box. You will then have to select the relevant version you wish to use. To do so, select the `Exact Version` option and enter a specific option you require or use the latest available `tag`, which should be selected for you.
+
+Once you click `Add Package` the last step will confirm the package product and target selection. The `approov-service-urlsession` is actually an open source wrapper layer that allows you to easily use Approov with `URLSession`. This has a further dependency to the closed source [Approov SDK](https://github.com/approov/approov-ios-sdk).
+
+Alternatively, use `cocoapods` and add the package dependencies similar to how they are used in the example `shapes-app/Podfile` in the [Quickstart](https://github.com/approov/quickstart-ios-swift-urlsession) repository.
+
+## USING APPROOV SERVICE
+The `ApproovURLSession` class mimics the interface of the `URLSession` class provided by Apple but includes an additional Approov attestation calls. The simplest way to use the `ApproovURLSession` class is to find and replace all the `URLSession` construction calls with `ApproovURLSession`. 
 
 ```swift
 import ApproovURLSessionPackage
-import Approov
+
+try! ApproovService.initialize("<enter-your-config-string-here>")
+let session = ApproovURLSession(URLSessionConfiguration.default)
 ```
 
-The primary session type remains `ApproovURLSession`.
+Additionally, the Approov SDK wrapper class, `ApproovService` needs to be initialized before using the `ApproovURLSession` object. The `<enter-your-config-string-here>` is a custom string that configures your Approov account access. This will have been provided in your Approov onboarding email (it will be something like `#123456#K/XPlLtfcwnWkzv99Wj5VmAxo4CrU267J1KlQyoz8Qo=`).
 
+For API domains that are configured to be protected with an Approov token, this adds the `Approov-Token` header and pins the connection. This may also substitute header values and query parameters when using secrets protection.
+
+## ERROR TYPES
+The `ApproovService` functions may throw specific errors to provide additional information:
+
+* `permanentError` might be due to a feature not enabled using the command line
+* `rejectionError` an attestation has been rejected, the `ARC` and `rejectionReasons` may contain specific device information that would help troubleshooting
+* `networkingError` generally can be retried since it can be temporary network issue
+* `pinningError` is a certificate error
+* `configurationError` a configuration feature is disabled or wrongly configured (i.e. attempting to initialize with different config from a previous instantiation) 
+* `initializationFailure` the ApproovService failed to be initialized (subsequent network requests will not be performed)
+
+## CHECKING IT WORKS
+Initially you won't have set which API domains to protect, so the interceptor will not add anything. It will have called Approov though and made contact with the Approov cloud service. You will see logging from Approov saying `unknown URL`.
+
+Your Approov onboarding email should contain a link allowing you to access [Live Metrics Graphs](https://approov.io/docs/latest/approov-usage-documentation/#metrics-graphs). After you've run your app with Approov integration you should be able to see the results in the live metrics within a minute or so. At this stage you could even release your app to get details of your app population and the attributes of the devices they are running upon.
+
+## NEXT STEPS
+To actually protect your APIs and/or secrets there are some further steps. Approov provides two different options for protection:
+
+* [API PROTECTION](https://github.com/approov/quickstart-ios-swift-urlsession/blob/master/API-PROTECTION.md): You should use this if you control the backend API(s) being protected and are able to modify them to ensure that a valid Approov token is being passed by the app. An [Approov Token](https://approov.io/docs/latest/approov-usage-documentation/#approov-tokens) is short lived cryptographically signed JWT proving the authenticity of the call.
+
+* [SECRETS PROTECTION](https://github.com/approov/quickstart-ios-swift-urlsession/blob/master/SECRETS-PROTECTION.md): This allows app secrets, including API keys for 3rd party services, to be protected so that they no longer need to be included in the released app code. These secrets are only made available to valid apps at runtime.
+
+Note that it is possible to use both approaches side-by-side in the same app.
+
+See [REFERENCE](REFERENCE.md) for a complete list of all of the `ApproovService` methods.
+
+## DATA TASK PUBLISHER
+The version of [`dataTaskPublisher(for:)`](https://developer.apple.com/documentation/foundation/urlsession/3329708-datataskpublisher) provided in `URLSession` does not add Approov protection.
+
+If you wish to use an Approov protected version then please call `dataTaskPublisherApproov` instead. Note though that this method may block when it is called when requesting network communication with the Approov cloud. Therefore you shouldn't call this method from the main UI thread.
+
+## AWAIT-ASYNC ASYNCHRONOUS TRANSFERS
+Note that the methods related to [Performing Asynchronous Transfers](https://developer.apple.com/documentation/foundation/urlsession#3842971) (introduced in iOS 15, and discussed in [Using URLSession’s async/await-powered APIs](https://wwdcbysundell.com/2021/using-async-await-with-urlsession/)) should not be called directly and do not provide Approov protection. This is because they are defined in an `extension` to `URLSession` and cannot be overridden by the Approov implementation. Instead various of the methods are provided with an identical method signature but have a `WithApproov` suffix in their name. The supported methods are as follows:
+
+`dataWithApproov(for request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse)`
+
+`dataWithApproov(from url: URL, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse)`
+
+`uploadWithApproov(for request: URLRequest, fromFile fileURL: URL, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse)`
+
+`uploadWithApproov(for request: URLRequest, from bodyData: Data, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse)`
+
+`downloadWithApproov(for request: URLRequest, delegate: URLSessionTaskDelegate? = nil) async throws -> (URL, URLResponse)`
+
+`downloadWithApproov(from url: URL, delegate: URLSessionTaskDelegate? = nil) async throws -> (URL, URLResponse)`
 
 # Changelog
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,9 +16,8 @@ Most methods either throw an `ApproovError` or return an `ApproovUpdateResponse`
 Initializes the SDK with the config obtained using `approov sdk -getConfigString` or
 in the original onboarding email. Note the initializer function should only ever be called once.
 Subsequent calls will be ignored since the ApproovSDK can only be initialized once; if however,
-an attempt is made to initialize with a different configuration (config) we throw an
-ApproovException.configurationError. If the Approov SDK fails to be initialized for some other
-reason, an `ApproovError.initializationFailure` is raised.
+an attempt is made to initialize with a different configuration (config), or the initialization
+fails for any other reason, an `ApproovError.initializationFailure` is raised.
 
 ```swift
 try ApproovService.initialize(config: "<config-string>")

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ We encourage all users of these service layers to update to the latest version f
 | Version | Supported          |
 | ------- | ------------------ |
 | 3.5.x   | :white_check_mark: |
-| < 3.4   | :x:                |
+| < 3.5   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionalities than later versions.
+We encourage all users of these service layers to update to the latest version for the best experience.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.5.x   | :white_check_mark: |
+| < 3.4   | :x:                |
+
+## Reporting a Vulnerability
+
+Thank you for letting us know about possible security vulnerabilities to this project.
+Please don't publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to.
+
+Your message will receive a prompt reply.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionalities than later versions.
+We maintain updates and patches for the latest release. Earlier versions will still work, but will have less functionality than later versions.
 We encourage all users of these service layers to update to the latest version for the best experience.
 
 | Version | Supported          |
@@ -12,7 +12,7 @@ We encourage all users of these service layers to update to the latest version f
 
 ## Reporting a Vulnerability
 
-Thank you for letting us know about possible security vulnerabilities to this project.
-Please don't publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to.
+Thank you for letting us know about possible security vulnerabilities in this project.
+Please don't publish details in a public issue or PR. Send us a private email at support@approov.io and please disclose which version your report refers to.
 
 Your message will receive a prompt reply.

--- a/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
@@ -161,7 +161,10 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                 sigId = "account"
                 guard let base64Signature = ApproovService.getAccountMessageSignature(message: message),
                       let decodedSignature = Data(base64Encoded: base64Signature) else {
-                    throw ApproovError.permanentError(message: "Failed to generate HMAC signature")
+                    if ApproovService.loggingLevel >= .error {
+                        os_log("ApproovService: account message signature unavailable, skipping signing", type: .error)
+                    }
+                    return request
                 }
                 signature = decodedSignature
             default:

--- a/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
@@ -500,12 +500,10 @@ public class SignatureParametersFactory {
             }
         }
 
-        if let algorithm = bodyDigestAlgorithm {
-            if bodyDigestRequired {
-                let bodyDigestCreated = try generateBodyDigest(provider: provider, requestParameters: requestParameters)
-                if !bodyDigestCreated {
-                    throw ApproovError.permanentError(message: "Failed to create required body digest")
-                }
+        if bodyDigestAlgorithm != nil {
+            let bodyDigestCreated = try generateBodyDigest(provider: provider, requestParameters: requestParameters)
+            if !bodyDigestCreated && bodyDigestRequired {
+                throw ApproovError.permanentError(message: "Failed to create required body digest")
             }
         }
 
@@ -569,22 +567,14 @@ public class SignatureParametersFactory {
     private static func getHTTPBody(_ request: URLRequest) -> Data? {
         if let body = request.httpBody {
             return body
-        } else if let bodyStream = request.httpBodyStream {
-            var data = Data()
-            bodyStream.open()
-            defer { bodyStream.close() }
-            let bufferSize = 1024
-            var buffer = [UInt8](repeating: 0, count: bufferSize)
-            while bodyStream.hasBytesAvailable {
-                let bytesRead = bodyStream.read(&buffer, maxLength: bufferSize)
-                if bytesRead < 0 {
-                    return nil
-                }
-                data.append(buffer, count: bytesRead)
-            }
-            return data
+        } else if request.httpBodyStream != nil {
+            // httpBodyStream is a one-shot stream; consuming it here would exhaust it
+            // before URLSession can send the request body. Return nil to skip digesting
+            // stream bodies gracefully rather than silently corrupting the upload.
+            return nil
         }
-        return Data()
+        // No body present — return nil so no Content-Digest is added.
+        return nil
     }
 
     /**

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -180,8 +180,9 @@ public class ApproovService {
 
     /**
      * Initializes the ApproovService with the config obtained using `approov sdk -getConfigString`
-     * or in the original onboarding email. The service layer always resets its own state on a
-     * successful call. If using a non-empty config, the platform SDK is contacted first; state is
+     * or in the original onboarding email. The service layer resets its own configuration state
+     * (except for any custom service mutator or the status-if-no-token setting) on a successful
+     * call. If using a non-empty config, the platform SDK is contacted first; state is
      * only modified after the SDK confirms success, preserving the current operating mode
      * (protected or bypass) if the call fails.
      *

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -194,7 +194,7 @@ public class ApproovService {
         try initializerQueue.sync {
             // If we are already initialized with a valid config, ignore any subsequent
             // empty config initialization
-            if serviceIsInitialized && !(configString?.isEmpty ?? true) && config.isEmpty {
+            if isApproovEnabledInternal && config.isEmpty {
                 if loggingLevel >= .info {
                     os_log("ApproovService already initialized with a valid config; ignoring empty configuration", type: .info)
                 }
@@ -270,6 +270,10 @@ public class ApproovService {
         }
     }
 
+    private static var isApproovEnabledInternal: Bool {
+        serviceIsInitialized && !(configString?.isEmpty ?? true)
+    }
+
     /**
      * Indicates whether Approov protection is enabled for this service layer
      * instance. If initialization used an empty config string then the layer is
@@ -279,7 +283,7 @@ public class ApproovService {
      */
     public static func isApproovEnabled() -> Bool {
         initializerQueue.sync {
-            serviceIsInitialized && !(configString?.isEmpty ?? true)
+            isApproovEnabledInternal
         }
     }
 

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -192,6 +192,14 @@ public class ApproovService {
      */
     public static func initialize(config: String, comment: String? = nil) throws {
         try initializerQueue.sync {
+            // If the service is already initialized, ignore any subsequent empty config initialization
+            if serviceIsInitialized && config.isEmpty {
+                if loggingLevel >= .info {
+                    os_log("ApproovService already initialized; ignoring empty configuration", type: .info)
+                }
+                return
+            }
+
             // Initialize the platform SDK if not in bypass mode (empty config).
             // State is only modified after the SDK confirms success, preserving the
             // current operating mode (protected or bypass) if the call fails.

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -179,56 +179,65 @@ public class ApproovService {
     }
 
     /**
-     * Initializes the SDK with the config obtained using `approov sdk -getConfigString` or
-     * in the original onboarding email. Note the initializer function should only ever be called once.
-     * Subsequent calls will be ignored since the ApproovSDK can only be initialized once; if however,
-     * an attempt is made to initialize with a different configuration (config) we throw an
-     * ApproovException.configurationError. If the Approov SDK fails to be initialized for some other
-     * reason, an .initializationFailure is raised.
+     * Initializes the ApproovService with the config obtained using `approov sdk -getConfigString`
+     * or in the original onboarding email. The service layer always resets its own state on a
+     * successful call. If using a non-empty config, the platform SDK is contacted first; state is
+     * only modified after the SDK confirms success, preserving the current operating mode
+     * (protected or bypass) if the call fails.
      *
      * @param config is the configuration to be used, or an empty string to bypass the actual initialization
      * @param comment is an optional comment to be passed to the SDK
      * @throws ApproovError if there was a problem
      */
     public static func initialize(config: String, comment: String? = nil) throws {
-        try initializerQueue.sync  {
-            let allowReinitialize = comment?.hasPrefix("reinit") == true
-            let allowEnableAfterEmptyInitialization =
-                serviceIsInitialized &&
-                (configString?.isEmpty == true) &&
-                !config.isEmpty
-            // check if we attempt to use a different configString
-            if serviceIsInitialized && !allowReinitialize && !allowEnableAfterEmptyInitialization {
-                // ignore multiple initialization calls that use the same configuration
-                if (config != configString) {
-                    // throw exception indicating we are attempting to use different config
-                    if loggingLevel >= .error {
-                        os_log("ApproovService: Attempting to initialize with different configuration", type: .error)
-                    }
-                    throw ApproovError.configurationError(message: "Attempting to initialize with a different configuration")
-                }
-                if loggingLevel >= .warning {
-                    os_log("ApproovService: Ignoring multiple ApproovService layer initializations with the same config");
-                }
-            } else {
+        try initializerQueue.sync {
+            // Initialize the platform SDK if not in bypass mode (empty config).
+            // State is only modified after the SDK confirms success, preserving the
+            // current operating mode (protected or bypass) if the call fails.
+            if !config.isEmpty {
                 do {
-                    if !config.isEmpty {
-                        // only initialize with a non-empty string as empty string used to bypass this
-                        try Approov.initialize(config, updateConfig: "auto", comment: comment)
+                    // Approov.initialize is an ObjC BOOL-returning method bridged to Swift as throwing.
+                    // BOOL=YES (first init)  → no throw  → SDK was just initialized.
+                    // BOOL=NO, no NSError   → Foundation._GenericObjCError code 0
+                    //                       → SDK already initialized — equivalent to boolean
+                    //                         false return on Android; log and continue.
+                    // Any other error       → genuine failure → re-throw.
+                    try Approov.initialize(config, updateConfig: "auto", comment: comment)
+                    if loggingLevel >= .info {
+                        os_log("ApproovService: Approov SDK initialized", type: .info)
                     }
                 } catch let error {
-                    // If the error is due to the SDK being initiliazed already, we ignore it otherwise we throw
+                    // If the error is due to the SDK being initialized already, we ignore it otherwise we throw.
+                    // This is an ObjC/Swift interop artifact: ObjC BOOL return of NO without an NSError
+                    // is bridged as Foundation._GenericObjCError with code 0.
                     let nsError = error as NSError
                     if nsError.code == 0, nsError.domain == "Foundation._GenericObjCError" {
                         if loggingLevel >= .info {
-                            os_log("ApproovService: Ignoring initialization error in Approov SDK: %@", type: .info, nsError.localizedDescription)
+                            os_log("ApproovService: Approov SDK already initialized", type: .info)
                         }
                     } else {
+                        // service-layer state NOT modified — prior operating mode preserved
                         throw ApproovError.initializationFailure(message: "Error initializing Approov SDK: \(nsError.localizedDescription)")
                     }
                 }
-                serviceIsInitialized = true
-                configString = config
+            }
+            // SDK succeeded (or bypass) — now reset and commit new service-layer state.
+            serviceIsInitialized = false
+            configString = config
+            proceedOnNetworkFail = false
+            bindingHeader = ""
+            approovTokenHeader = "Approov-Token"
+            approovTokenPrefix = ""
+            approovTraceIDHeader = "Approov-TraceID"
+            substitutionHeaders = Dictionary()
+            substitutionQueryParams = Set()
+            exclusionURLRegexs = Dictionary()
+            failureCacheQueue.sync {
+                cachedFailureResult = nil
+                cachedFailureTime = nil
+            }
+            serviceIsInitialized = true
+            if !config.isEmpty {
                 Approov.setUserProperty("approov-service-urlsession")
             }
         }

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -192,10 +192,11 @@ public class ApproovService {
      */
     public static func initialize(config: String, comment: String? = nil) throws {
         try initializerQueue.sync {
-            // If the service is already initialized, ignore any subsequent empty config initialization
-            if serviceIsInitialized && config.isEmpty {
+            // If we are already initialized with a valid config, ignore any subsequent
+            // empty config initialization
+            if serviceIsInitialized && !(configString?.isEmpty ?? true) && config.isEmpty {
                 if loggingLevel >= .info {
-                    os_log("ApproovService already initialized; ignoring empty configuration", type: .info)
+                    os_log("ApproovService already initialized with a valid config; ignoring empty configuration", type: .info)
                 }
                 return
             }

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -224,14 +224,16 @@ public class ApproovService {
             // SDK succeeded (or bypass) — now reset and commit new service-layer state.
             serviceIsInitialized = false
             configString = config
-            proceedOnNetworkFail = false
-            bindingHeader = ""
-            approovTokenHeader = "Approov-Token"
-            approovTokenPrefix = ""
-            approovTraceIDHeader = "Approov-TraceID"
-            substitutionHeaders = Dictionary()
-            substitutionQueryParams = Set()
-            exclusionURLRegexs = Dictionary()
+            stateQueue.sync {
+                proceedOnNetworkFail = false
+                bindingHeader = ""
+                approovTokenHeader = "Approov-Token"
+                approovTokenPrefix = ""
+                approovTraceIDHeader = "Approov-TraceID"
+                substitutionHeaders = Dictionary()
+                substitutionQueryParams = Set()
+                exclusionURLRegexs = Dictionary()
+            }
             failureCacheQueue.sync {
                 cachedFailureResult = nil
                 cachedFailureTime = nil
@@ -317,6 +319,9 @@ public class ApproovService {
      */
     public static func setDevKey(devKey: String) {
         if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: setDevKey: SDK not initialized", type: .error)
+            }
             return
         }
         stateQueue.sync {

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -316,6 +316,9 @@ public class ApproovService {
      * @param devKey is the development key to be used
      */
     public static func setDevKey(devKey: String) {
+        if !isApproovEnabled() {
+            return
+        }
         stateQueue.sync {
             Approov.setDevKey(devKey)
             if loggingLevel >= .debug {

--- a/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -58,7 +58,12 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
     /// Initializing with an empty config should keep the service layer initialized
     /// while forwarding requests without Approov mutations.
     func testInitializeWithEmptyConfigForwardsPlainRequests() throws {
-        try reinitializeServiceWithTargetHost()
+        MiniSDKAttesterProxyController.reset()
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        let domainsJSON = "\"protectedDomains\": [\"\(targetHost)\"]"
+        MiniSDKAttesterProxyController.loadScenarioJSON(scenarioJSON(caseName: uniqueCaseName(prefix: "target-host"), body: domainsJSON))
+        ApproovService.resetForTesting()
+        ApproovService.setLoggingLevel(.off)
         try ApproovService.initialize(config: "", comment: "reinit-empty-config")
 
         XCTAssertTrue(ApproovService.isInitialized())
@@ -76,7 +81,12 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
     /// Initializing first with an empty config should allow a later valid config
     /// to enable Approov protection at runtime.
     func testInitializeWithEmptyConfigCanLaterEnableApproov() throws {
-        try reinitializeServiceWithTargetHost()
+        MiniSDKAttesterProxyController.reset()
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        let domainsJSON = "\"protectedDomains\": [\"\(targetHost)\"]"
+        MiniSDKAttesterProxyController.loadScenarioJSON(scenarioJSON(caseName: uniqueCaseName(prefix: "target-host"), body: domainsJSON))
+        ApproovService.resetForTesting()
+        ApproovService.setLoggingLevel(.off)
         try ApproovService.initialize(config: "", comment: "reinit-empty-config")
 
         XCTAssertTrue(ApproovService.isInitialized())

--- a/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -45,10 +45,11 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
 
         let differentConfig = "#cb-other#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo="
         XCTAssertThrowsError(try ApproovService.initialize(config: differentConfig, comment: nil)) { error in
-            guard case let ApproovError.configurationError(message) = error else {
-                return XCTFail("Expected configurationError, got \(error)")
+            guard case let ApproovError.initializationFailure(message) = error else {
+                return XCTFail("Expected initializationFailure, got \(error)")
             }
-            XCTAssertEqual(message, "Attempting to initialize with a different configuration")
+            XCTAssertTrue(message.contains("Approov SDK already initialized with a different configuration"),
+                          "Unexpected message: \(message)")
         }
     }
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,7 +10,7 @@ You can initialize the `ApproovService` with an empty configuration string if yo
 > try? ApproovService.initialize(config: "")
 > ```
 
-When initialized this way, the `URLSession` objects returned or updated by the service behave exactly like standard instances. They will not perform token injection, message signing, secure string substitution, or dynamic pinning. You can enable full Approov protection later in the application lifecycle by calling `ApproovService.initialize(config)` with a valid configuration string.
+When initialized this way, the `URLSession` objects returned or updated by the service behave exactly like standard instances. They will not perform token injection, message signing, secure string substitution, or dynamic pinning. You can enable full Approov protection later in the application lifecycle by calling `ApproovService.initialize(config: config)` with a valid configuration string.
 
 # Approov Service Mutator
 


### PR DESCRIPTION
Simplifies the ApproovService initialization flow and updates governance documentation.

## Changes
- Simplified `initialize` — removed service-layer re-initialization guards (same-config short-circuit, `reinit` comment check). The service layer now always resets its own state and forwards non-empty config directly to the platform SDK.
- Adds SECURITY.md with security policy, supported versions table, and vulnerability reporting instructions.
- Updates LICENSE copyright year.
- Fixes grammar in SECURITY.md (from feature/3.6.0 merge).

Related: approov/core-project-approov#560
