### PR TITLE
feat: public signRequest API and ApproovUpdateResponse visibility (3.5.10)

### DIFF
--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ApproovURLSession"
-  s.version      = "3.5.9"
+  s.version      = "3.5.10"
   s.summary      = "Approov mobile attestation SDK"
   s.description  = <<-DESC
     Approov SDK integrates security attestation and secure string fetching for both iOS and watchOS apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - New `signRequest(_:sessionConfig:)` convenience method on `ApproovService` that applies Approov protection (token, substitutions, and message signing when configured) to a `URLRequest` and returns the protected request directly. Designed for HTTP transports that own their own `URLSession` (e.g. Apollo iOS, gRPC-Swift) where substituting `ApproovURLSession` is not possible.
 
 ### Changed
-- Made all members of `ApproovUpdateResponse` (`request`, `decision`, `sdkMessage`, `error`) `public`. Previously they had `internal` access, preventing external modules from reading the response fields returned by `updateRequestWithApproov`.
+- Made all members of `ApproovUpdateResponse` (`request`, `decision`, `sdkMessage`, `error`) publicly readable (`public internal(set)`). Previously they had `internal` access, preventing external modules from reading the response fields returned by `updateRequestWithApproov`.
+- `initialize(config:comment:)` now resets `serviceMutator` and `useApproovStatusIfNoToken` to defaults on each successful call, alongside the existing resets of substitution headers, exclusion regexes, and binding header.
+
+### Fixed
+- `PinningURLSessionDelegate`: In empty-config bypass mode, the challenge handler now calls `.performDefaultHandling` rather than accepting the server trust via `.useCredential`. This ensures OS-level certificate validation always runs even when Approov dynamic pinning is skipped.
 
 ## [3.5.9] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [3.5.10] - 2026-06-08
+
+### Added
+- New `signRequest(_:sessionConfig:)` convenience method on `ApproovService` that applies Approov protection (token, substitutions, and message signing when configured) to a `URLRequest` and returns the protected request directly. Designed for HTTP transports that own their own `URLSession` (e.g. Apollo iOS, gRPC-Swift) where substituting `ApproovURLSession` is not possible.
+
+### Changed
+- Made all members of `ApproovUpdateResponse` (`request`, `decision`, `sdkMessage`, `error`) `public`. Previously they had `internal` access, preventing external modules from reading the response fields returned by `updateRequestWithApproov`.
+
 ## [3.5.9] - 2026-06-02
 
 ### Changed

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import Foundation
 import PackageDescription
 // The release tag for this version of ApproovURLSession
-let releaseTAG = "3.5.9"
+let releaseTAG = "3.5.10"
 // SDK package version (used for both iOS and watchOS)
 let sdkVersion: Version = "3.5.3"
 let useMiniSDK = ProcessInfo.processInfo.environment["APPROOV_USE_MINI_SDK"] == "1"

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -357,8 +357,39 @@ let arc = ApproovService.getLastARC()
 ```
 
 ## updateRequestWithApproov
-Updates a `URLRequest` with Approov protection (token, substitutions, etc.). Returns an `ApproovUpdateResponse` describing the decision and any error.
+Updates a `URLRequest` with Approov protection (token, substitutions, etc.). Returns an `ApproovUpdateResponse` describing the decision and any error. All members of `ApproovUpdateResponse` (`request`, `decision`, `sdkMessage`, `error`) are public.
 
 ```swift
 let response = ApproovService.updateRequestWithApproov(request: request, sessionConfig: session.configuration)
+switch response.decision {
+case .ShouldProceed:
+    // use response.request
+case .ShouldIgnore:
+    // use original request unchanged
+case .ShouldRetry:
+    // retry after a delay
+case .ShouldFail:
+    // handle response.error
+}
+```
+
+## signRequest
+Convenience method that applies Approov protection to a `URLRequest` and returns the protected request directly. This is intended for use with HTTP transports that own their own `URLSession` (e.g. Apollo iOS, gRPC-Swift) where substituting `ApproovURLSession` is not possible. The returned request includes the Approov token and any header/query substitutions. Message signing headers are also applied if a signing mutator is configured (see `USAGE.md`).
+
+The method calls `updateRequestWithApproov` internally and interprets the decision:
+- `.ShouldProceed`: returns the updated (protected) request.
+- `.ShouldIgnore`: returns the original request unchanged.
+- `.ShouldRetry`: throws `ApproovError.networkingError` so the caller can retry.
+- `.ShouldFail`: throws the underlying error (or `ApproovError.permanentError`).
+
+Note: This method performs a synchronous Approov token fetch and may block briefly while the SDK contacts the Approov cloud. Call it from a background thread or async context to avoid blocking the main thread.
+
+```swift
+let protectedRequest = try ApproovService.signRequest(originalRequest)
+```
+
+An optional `URLSessionConfiguration` can be provided to include additional session-level headers:
+
+```swift
+let protectedRequest = try ApproovService.signRequest(originalRequest, sessionConfig: session.configuration)
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -395,4 +395,3 @@ let protectedRequest = try ApproovService.signRequest(originalRequest, sessionCo
 ```
 
 > **Important — Dynamic Pinning:** `signRequest` does **not** apply dynamic TLS pinning. When you use `ApproovURLSession`, its delegate automatically validates the server's TLS certificate against Approov's dynamic pin set (`Approov.getPins("public-key-sha256")`). A plain `URLSession` bypasses this entirely. If your transport owns its own `URLSession` and delegate, you are responsible for implementing certificate pinning separately — for example by calling `Approov.getPins("public-key-sha256")` in your `URLSessionDelegate`'s `urlSession(_:didReceive:completionHandler:)` method and verifying the server certificate's SPKI hash against the returned set.
-

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -388,7 +388,7 @@ Note: This method performs a synchronous Approov token fetch and may block brief
 let protectedRequest = try ApproovService.signRequest(originalRequest)
 ```
 
-An optional `URLSessionConfiguration` can be provided to include additional session-level headers:
+An optional `URLSessionConfiguration` can be provided so `signRequest` can consider any session-level `httpAdditionalHeaders` for token binding and header substitution lookups (these headers are not added to the returned request):
 
 ```swift
 let protectedRequest = try ApproovService.signRequest(originalRequest, sessionConfig: session.configuration)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -357,7 +357,9 @@ let arc = ApproovService.getLastARC()
 ```
 
 ## updateRequestWithApproov
-Updates a `URLRequest` with Approov protection (token, substitutions, etc.). Returns an `ApproovUpdateResponse` describing the decision and any error. All members of `ApproovUpdateResponse` (`request`, `decision`, `sdkMessage`, `error`) are public.
+Updates a `URLRequest` with Approov protection (token, substitutions, etc.). Returns an `ApproovUpdateResponse` describing the decision and any error. All members of `ApproovUpdateResponse` (`request`, `decision`, `sdkMessage`, `error`) are publicly readable but can only be written within the package.
+
+An optional `URLSessionConfiguration` can be provided. Its `httpAdditionalHeaders` are consulted for token binding and secure string substitution lookups only — they are **not** merged into the returned `URLRequest`.
 
 ```swift
 let response = ApproovService.updateRequestWithApproov(request: request, sessionConfig: session.configuration)
@@ -381,6 +383,10 @@ The method calls `updateRequestWithApproov` internally and interprets the decisi
 - `.ShouldIgnore`: returns the original request unchanged.
 - `.ShouldRetry`: throws `ApproovError.networkingError` so the caller can retry.
 - `.ShouldFail`: throws the underlying error (or `ApproovError.permanentError`).
+
+> **Error handling:** The default mutator always throws `ApproovError`. However, a custom mutator may store any `Error` in `ApproovUpdateResponse.error`, so callers should catch `Error` rather than `ApproovError` specifically to avoid silently swallowing errors from custom mutators.
+
+> **Bypass mode:** If the service layer was initialized with an empty config string (`isApproovEnabled()` returns `false`), `signRequest` returns the **original request unchanged** without Approov protection and without throwing. Callers that need to enforce that protection is active should check `ApproovService.isApproovEnabled()` before calling `signRequest` and fail explicitly if Approov is not enabled.
 
 Note: This method performs a synchronous Approov token fetch and may block briefly while the SDK contacts the Approov cloud. Call it from a background thread or async context to avoid blocking the main thread.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -290,7 +290,7 @@ Performs an Approov token fetch for the given URL. This should be used in situat
 is not possible to use the networking interception to add the token. This will
 likely require network access so may take some time to complete. If the attestation fails
 for any reason then an `ApproovError` is thrown. This will be `ApproovNetworkException` for
-networking issues wher a user initiated retry of the operation should be allowed. Note that
+networking issues where a user initiated retry of the operation should be allowed. Note that
 the returned token should *NEVER* be cached by your app, you should call this function when
 it is needed.
 
@@ -384,7 +384,7 @@ The method calls `updateRequestWithApproov` internally and interprets the decisi
 - `.ShouldRetry`: throws `ApproovError.networkingError` so the caller can retry.
 - `.ShouldFail`: throws the underlying error (or `ApproovError.permanentError`).
 
-> **Error handling:** The default mutator always throws `ApproovError`. However, a custom mutator may store any `Error` in `ApproovUpdateResponse.error`, so callers should catch `Error` rather than `ApproovError` specifically to avoid silently swallowing errors from custom mutators.
+> **Error handling:** This method always throws `ApproovError`. Non-`ApproovError` throws from custom mutators are wrapped as `ApproovError.permanentError` by the service layer, so callers can catch `ApproovError` specifically.
 
 > **Bypass mode:** If the service layer was initialized with an empty config string (`isApproovEnabled()` returns `false`), `signRequest` returns the **original request unchanged** without Approov protection and without throwing. Callers that need to enforce that protection is active should check `ApproovService.isApproovEnabled()` before calling `signRequest` and fail explicitly if Approov is not enabled.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -393,3 +393,6 @@ An optional `URLSessionConfiguration` can be provided to include additional sess
 ```swift
 let protectedRequest = try ApproovService.signRequest(originalRequest, sessionConfig: session.configuration)
 ```
+
+> **Important — Dynamic Pinning:** `signRequest` does **not** apply dynamic TLS pinning. When you use `ApproovURLSession`, its delegate automatically validates the server's TLS certificate against Approov's dynamic pin set (`Approov.getPins("public-key-sha256")`). A plain `URLSession` bypasses this entirely. If your transport owns its own `URLSession` and delegate, you are responsible for implementing certificate pinning separately — for example by calling `Approov.getPins("public-key-sha256")` in your `URLSessionDelegate`'s `urlSession(_:didReceive:completionHandler:)` method and verifying the server certificate's SPKI hash against the returned set.
+

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,26 +14,26 @@ Most methods either throw an `ApproovError` or return an `ApproovUpdateResponse`
 
 ## initialize
 Initializes the SDK with the config obtained using `approov sdk -getConfigString` or
-in the original onboarding email. Note the initializer function should only ever be called once.
-Subsequent calls will be ignored since the ApproovSDK can only be initialized once; if however,
-an attempt is made to initialize with a different configuration (config), or the initialization
-fails for any other reason, an `ApproovError.initializationFailure` is raised.
+in the original onboarding email. In the vast majority of integrations, `initialize` should be called **once** during app startup — typically in `application(_:didFinishLaunchingWithOptions:)` or the root view controller. Each successful call resets all service-layer configuration (substitution headers, exclusion URL regexes, binding header, service mutator, `useApproovStatusIfNoToken`) to defaults, so any configuration applied after initialization would be lost on a repeated call.
+
+The most common scenario where `initialize` is called more than once is when **multiple service layers** coexist in the same app (e.g. `approov-service-urlsession` alongside `approov-service-alamofire`, or a React Native bridge layer). Since only one instance of the native Approov SDK can be active at any time, the second service layer's `initialize` call with the same config is handled gracefully — the native SDK reports it is already initialized, and the service layer proceeds normally. Each service layer maintains its own independent configuration state (substitution headers, exclusion regexes, etc.).
+
+The native SDK (3.5+) accepts a same-config re-initialization by returning `false`/`NO` without error, which this service layer handles gracefully. However, calling `initialize` again with the same config still resets the service-layer state, so there is no benefit to doing so in normal app flows with a single service layer.
 
 ```swift
 try ApproovService.initialize(config: "<config-string>")
 ```
 
-Optional comment can be provided to configure the platform SDK:
+An optional `comment` parameter is forwarded directly to the native SDK. The `comment` should be `nil` unless you are using [SDK initialization options](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-with-options) or performing an explicit [SDK reinitialization](https://approov.io/docs/latest/approov-direct-sdk-integration/#reinitializing-the-sdk). These are advanced use cases — for example, passing `"options:no-install-key"` to disable install keys, or `"reinit"` to reset internal SDK state. Some of these flows require calling `initialize` a second time with the same config, which is fully supported by the service layer. Note that each call still resets the service-layer configuration to defaults, so any substitution headers, exclusion regexes, etc. must be re-applied after the second call.
 
 ```swift
-try ApproovService.initialize(config: "<config-string>", comment: "my-comment")
+try ApproovService.initialize(config: "<config-string>", comment: "options:no-install-key")
 ```
 
-Passing an empty config string bypasses Approov SDK initialization. In that mode the service layer still reports itself as initialized, but requests are forwarded as plain `URLSession` traffic without Approov token injection, message signing, secure strings, or pinning.
+If an attempt is made to initialize with a **different** non-empty config, an `ApproovError.initializationFailure` is raised — the existing operating mode is preserved. To switch to a different config at runtime you must use the `reinit` comment flow as described in the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#reinitializing-the-sdk).
 
-This empty-config mode is intended as a bootstrap or bypass state for advanced integrations. A later call to `initialize()` with a valid non-empty config string is allowed and will then enable the native Approov SDK at runtime. By contrast, reinitializing from one non-empty config string to a different non-empty config string is still rejected unless you are intentionally using a supported same-config `reinit...` flow.
+Passing an empty config string bypasses Approov SDK initialization. In that mode the service layer still reports itself as initialized, but requests are forwarded as plain `URLSession` traffic without Approov token injection, message signing, secure strings, or pinning. A later call to `initialize()` with a valid non-empty config string will then enable the native Approov SDK at runtime. By contrast, once initialized with a valid config, a subsequent empty-config call is silently ignored — the service layer cannot be downgraded from protected to bypass mode.
 
-Initialization comments starting with `options:` should be treated as initial-call options, not as a repeated runtime update path. Repeated same-config `options:...` calls may fail at the native SDK level. If another service layer has already initialized the native SDK with the same config, URLSession tolerates the benign already-initialized outcome, while still surfacing real different-configuration failures.
 
 ## isInitialized
 Returns whether the service layer has been initialized.

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -62,10 +62,10 @@ public enum ApproovFetchDecision {
 
 // result from adding Approov protection to a request
 public struct ApproovUpdateResponse {
-    public var request: URLRequest
-    public var decision: ApproovFetchDecision
-    public var sdkMessage: String
-    public var error: Error?
+    public internal(set) var request: URLRequest
+    public internal(set) var decision: ApproovFetchDecision
+    public internal(set) var sdkMessage: String
+    public internal(set) var error: Error?
 }
 
 // Log level for controlling the verbosity of os_log output from the ApproovService

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -62,10 +62,10 @@ public enum ApproovFetchDecision {
 
 // result from adding Approov protection to a request
 public struct ApproovUpdateResponse {
-    var request: URLRequest
-    var decision: ApproovFetchDecision
-    var sdkMessage: String
-    var error: Error?
+    public var request: URLRequest
+    public var decision: ApproovFetchDecision
+    public var sdkMessage: String
+    public var error: Error?
 }
 
 // Log level for controlling the verbosity of os_log output from the ApproovService
@@ -1286,6 +1286,49 @@ public class ApproovService {
         }
 
         return response
+    }
+
+    /**
+     * Convenience method that applies Approov protection to a URLRequest and returns the
+     * protected request directly. This is intended for use with HTTP transports that own their
+     * own URLSession (e.g. Apollo iOS, gRPC-Swift) where substituting ApproovURLSession is
+     * not possible.
+     *
+     * The method calls `updateRequestWithApproov` internally and interprets the decision:
+     * - `.ShouldProceed`: returns the updated (protected) request.
+     * - `.ShouldIgnore`: returns the original request unchanged.
+     * - `.ShouldRetry`: throws `ApproovError.networkingError` so the caller can retry.
+     * - `.ShouldFail`: throws the underlying error (or `ApproovError.permanentError`).
+     *
+     * Note: This method performs a synchronous Approov token fetch and may block briefly
+     * while the SDK contacts the Approov cloud. Call it from a background thread or async
+     * context to avoid blocking the main thread.
+     *
+     * Example usage with Apollo iOS:
+     * ```swift
+     * let protected = try ApproovService.signRequest(original)
+     * // hand `protected` to your Apollo NetworkTransport
+     * ```
+     *
+     * @param request the original URLRequest to be protected
+     * @param sessionConfig optional URLSessionConfiguration to include additional headers
+     * @return the URLRequest with Approov token and substitutions applied (message signing included when configured)
+     * @throws ApproovError if the request should not proceed
+     */
+    public static func signRequest(_ request: URLRequest, sessionConfig: URLSessionConfiguration? = nil) throws -> URLRequest {
+        let response = updateRequestWithApproov(request: request, sessionConfig: sessionConfig)
+        switch response.decision {
+        case .ShouldProceed:
+            return response.request
+        case .ShouldIgnore:
+            return request
+        case .ShouldRetry:
+            throw response.error ?? ApproovError.networkingError(
+                message: "Approov token fetch failed with a retryable error: \(response.sdkMessage)")
+        case .ShouldFail:
+            throw response.error ?? ApproovError.permanentError(
+                message: "Approov token fetch failed: \(response.sdkMessage)")
+        }
     }
 
     static func resetForTesting() {

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -1059,7 +1059,7 @@ public class ApproovService {
      *
      * @param request is the original request to be made
      * @param sessionConfig is any URLSessionConfiguration whose httpAdditionalHeaders are consulted for token binding and header substitution lookups (these headers are not merged into the returned request)
-     * @return ApproovUpdateResponse providing an updated requets, plus an errors and status
+     * @return ApproovUpdateResponse providing an updated request, plus any error and status
      */
     public static func updateRequestWithApproov(request: URLRequest, sessionConfig: URLSessionConfiguration?) -> ApproovUpdateResponse {
         var changes = ApproovRequestMutations()
@@ -1321,7 +1321,14 @@ public class ApproovService {
      * @param request the original URLRequest to be protected
      * @param sessionConfig optional URLSessionConfiguration whose httpAdditionalHeaders are consulted for token binding and header substitution lookups (these headers are not merged into the returned request)
      * @return the URLRequest with Approov token and substitutions applied (message signing included when configured)
-     * @throws ApproovError if the request should not proceed
+     * @throws Error if the request should not proceed. The default mutator always produces an
+     *         ApproovError, but a custom mutator may store any Error in ApproovUpdateResponse.error,
+     *         so callers should catch Error rather than ApproovError specifically.
+     *
+     * Note: In bypass mode (service layer initialized with an empty config string,
+     * isApproovEnabled() == false), this method returns the original request unchanged without
+     * Approov protection and without throwing. Callers that must enforce protection should
+     * check ApproovService.isApproovEnabled() before calling signRequest.
      */
     public static func signRequest(_ request: URLRequest, sessionConfig: URLSessionConfiguration? = nil) throws -> URLRequest {
         let response = updateRequestWithApproov(request: request, sessionConfig: sessionConfig)

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -240,9 +240,11 @@ public class ApproovService {
                 approovTokenHeader = "Approov-Token"
                 approovTokenPrefix = ""
                 approovTraceIDHeader = "Approov-TraceID"
+                serviceMutator = ApproovServiceMutatorDefault.shared
                 substitutionHeaders = Dictionary()
                 substitutionQueryParams = Set()
                 exclusionURLRegexs = Dictionary()
+                useApproovStatusIfNoToken = false
             }
             failureCacheQueue.sync {
                 cachedFailureResult = nil

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -1058,7 +1058,7 @@ public class ApproovService {
      * perform header or query parameter substitutions to include protected secrets.
      *
      * @param request is the original request to be made
-     * @param sessionConfig is any URLSessionConfiguration from which additional headers can be obtained
+     * @param sessionConfig is any URLSessionConfiguration whose httpAdditionalHeaders are consulted for token binding and header substitution lookups (these headers are not merged into the returned request)
      * @return ApproovUpdateResponse providing an updated requets, plus an errors and status
      */
     public static func updateRequestWithApproov(request: URLRequest, sessionConfig: URLSessionConfiguration?) -> ApproovUpdateResponse {
@@ -1319,7 +1319,7 @@ public class ApproovService {
      * ```
      *
      * @param request the original URLRequest to be protected
-     * @param sessionConfig optional URLSessionConfiguration to include additional headers
+     * @param sessionConfig optional URLSessionConfiguration whose httpAdditionalHeaders are consulted for token binding and header substitution lookups (these headers are not merged into the returned request)
      * @return the URLRequest with Approov token and substitutions applied (message signing included when configured)
      * @throws ApproovError if the request should not proceed
      */

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -187,8 +187,8 @@ public class ApproovService {
     /**
      * Initializes the ApproovService with the config obtained using `approov sdk -getConfigString`
      * or in the original onboarding email. The service layer resets its own configuration state
-     * (except for any custom service mutator or the status-if-no-token setting) on a successful
-     * call. If using a non-empty config, the platform SDK is contacted first; state is
+     * on a successful call, including any custom service mutator and the status-if-no-token
+     * setting. If using a non-empty config, the platform SDK is contacted first; state is
      * only modified after the SDK confirms success, preserving the current operating mode
      * (protected or bypass) if the call fails.
      *

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -764,7 +764,7 @@ public class ApproovService {
      * is not possible to use the networking interception to add the token. This will
      * likely require network access so may take some time to complete. If the attestation fails
      * for any reason then an ApproovError is thrown. This will be ApproovNetworkException for
-     * networking issues wher a user initiated retry of the operation should be allowed. Note that
+     * networking issues where a user initiated retry of the operation should be allowed. Note that
      * the returned token should NEVER be cached by your app, you should call this function when
      * it is needed.
      *
@@ -1321,9 +1321,9 @@ public class ApproovService {
      * @param request the original URLRequest to be protected
      * @param sessionConfig optional URLSessionConfiguration whose httpAdditionalHeaders are consulted for token binding and header substitution lookups (these headers are not merged into the returned request)
      * @return the URLRequest with Approov token and substitutions applied (message signing included when configured)
-     * @throws Error if the request should not proceed. The default mutator always produces an
-     *         ApproovError, but a custom mutator may store any Error in ApproovUpdateResponse.error,
-     *         so callers should catch Error rather than ApproovError specifically.
+     * @throws ApproovError if the request should not proceed. Non-`ApproovError` throws from custom
+     *         mutators are wrapped as `ApproovError.permanentError` by the service layer, so callers
+     *         can always catch `ApproovError` specifically.
      *
      * Note: In bypass mode (service layer initialized with an empty config string,
      * isApproovEnabled() == false), this method returns the original request unchanged without

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -155,6 +155,12 @@ public class ApproovService {
      * @return String of the last ARC or empty string if there was none
      */
     public static func getLastARC() -> String {
+        if !isApproovEnabled() {
+            if loggingLevel >= .error {
+                os_log("ApproovService: getLastARC: SDK not initialized", type: .error)
+            }
+            return ""
+        }
         // We have to get the current config and obtain one protected API endpoint at least
         // get the dynamic pins from Approov
         guard let approovPins = Approov.getPins("public-key-sha256") else {

--- a/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
+++ b/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
@@ -131,13 +131,30 @@ class PinningURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDel
                 // delegate any challenge that is not to do with pinning
                 userDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
             } else {
-                // the user is not providing a delegate so we need to invoke the completion handler since we only deal with certificate pinning
-                completionHandler(.useCredential, nil)
+                // We only handle server trust challenges. For all other challenge types (e.g. HTTP
+                // Basic Auth, client certificates) we have no credential to offer, so we ask the OS
+                // to apply its default handling rather than supplying a nil credential with
+                // .useCredential (which is undefined behaviour per Apple's documentation).
+                completionHandler(.performDefaultHandling, nil)
             }
             return // return after handling non-pinning challenge
         }
         
         // we have a server trust challenge
+        // In bypass mode (empty-config initialization) skip dynamic pinning, but still require the OS
+        // to perform standard certificate chain validation. Returning the raw SecTrust with
+        // .useCredential without evaluating it can silently accept untrusted certificates on some
+        // iOS versions. .performDefaultHandling delegates full trust evaluation to the OS.
+        if !ApproovService.isApproovEnabled() {
+            if let userDelegate = optionalURLDelegate,
+               userDelegate.responds(to: #selector(URLSessionDelegate.urlSession(_:didReceive:completionHandler:))) {
+                userDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+            } else {
+                completionHandler(.performDefaultHandling, nil)
+            }
+            return
+        }
+        
         // Build a canonical URL including port so mutator decisions align with host+port semantics.
         var components = URLComponents()
         components.scheme = challenge.protectionSpace.`protocol` ?? "https"
@@ -193,13 +210,31 @@ class PinningURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDel
                 // fall back to session-level delegate handling if provided
                 userDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
             } else {
-                // the user is not providing a delegate so we need to invoke the completion handler since we only deal with certificate pinning
-                completionHandler(.useCredential, nil)
+                // We only handle server trust challenges. For all other challenge types (e.g. HTTP
+                // Basic Auth, client certificates) we have no credential to offer, so we ask the OS
+                // to apply its default handling rather than supplying a nil credential with
+                // .useCredential (which is undefined behaviour per Apple's documentation).
+                completionHandler(.performDefaultHandling, nil)
             }
             return
         }
         
         // we have a server trust challenge
+        // In bypass mode (empty-config initialization) skip dynamic pinning but preserve OS-level
+        // certificate trust validation. See session-level handler for full rationale.
+        if !ApproovService.isApproovEnabled() {
+            if let taskDelegate = optionalURLDelegate as? URLSessionTaskDelegate,
+               taskDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didReceive:completionHandler:))) {
+                taskDelegate.urlSession?(session, task: task, didReceive: challenge, completionHandler: completionHandler)
+            } else if let userDelegate = optionalURLDelegate,
+                      userDelegate.responds(to: #selector(URLSessionDelegate.urlSession(_:didReceive:completionHandler:))) {
+                userDelegate.urlSession?(session, didReceive: challenge, completionHandler: completionHandler)
+            } else {
+                completionHandler(.performDefaultHandling, nil)
+            }
+            return
+        }
+        
         if !shouldApplyPinning(for: task.currentRequest ?? task.originalRequest) {
             if let taskDelegate = optionalURLDelegate as? URLSessionTaskDelegate,
                taskDelegate.responds(to: #selector(URLSessionTaskDelegate.urlSession(_:task:didReceive:completionHandler:))) {
@@ -531,13 +566,8 @@ class PinningURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDel
      *  @return SecTrust?: valid SecTrust if authentication should proceed, nil otherwise
      */
     private func shouldAcceptAuthenticationChallenge(challenge: URLAuthenticationChallenge) throws -> SecTrust? {
-        // If the service layer is not enabled (empty-config bypass), skip dynamic pinning
-        // entirely. Without this guard a multi-service-layer app where another SDK initialized
-        // the native Approov SDK would enforce pins on requests that should behave like a
-        // standard URLSession.
-        if !ApproovService.isApproovEnabled() {
-            return challenge.protectionSpace.serverTrust
-        }
+        // Bypass-mode early return is now handled by the calling challenge handlers before
+        // this method is invoked, so this point is only reached when Approov is enabled.
 
         // check we have a server trust, ignore any other challenges
         guard let serverTrust = challenge.protectionSpace.serverTrust else {

--- a/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
+++ b/Sources/ApproovURLSession/PinningURLSessionDelegate.swift
@@ -531,6 +531,14 @@ class PinningURLSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDel
      *  @return SecTrust?: valid SecTrust if authentication should proceed, nil otherwise
      */
     private func shouldAcceptAuthenticationChallenge(challenge: URLAuthenticationChallenge) throws -> SecTrust? {
+        // If the service layer is not enabled (empty-config bypass), skip dynamic pinning
+        // entirely. Without this guard a multi-service-layer app where another SDK initialized
+        // the native Approov SDK would enforce pins on requests that should behave like a
+        // standard URLSession.
+        if !ApproovService.isApproovEnabled() {
+            return challenge.protectionSpace.serverTrust
+        }
+
         // check we have a server trust, ignore any other challenges
         guard let serverTrust = challenge.protectionSpace.serverTrust else {
             return nil

--- a/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -322,6 +322,135 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
         XCTAssertNotNil(getHeader(from: reply, key: "Approov-TraceID"))
     }
 
+    /// §2 Public Request Signing
+    ///
+    /// signRequest() should return a protected request that can be handed to an
+    /// HTTP transport that owns its own URLSession. This mirrors
+    /// updateRequestWithApproov's token, substitution, binding, and message
+    /// signing behavior without using ApproovURLSession for the final request.
+    func testSignRequestAddsTokenSubstitutionsBindingHashAndSignatureHeaders() throws {
+        let targetHost = try XCTUnwrap(URL(string: targetURLString)?.host)
+        try reinitializeService(
+            scenarioJSON: scenarioJSON(
+                caseName: uniqueCaseName(prefix: "sign-request"),
+                body: """
+                "protectedDomains": ["\(targetHost)"],
+                "initialSecureStrings": {
+                  "header-key": "header-secret",
+                  "query-key": "query-secret"
+                }
+                """
+            ),
+            comment: "reinit-sign-request"
+        )
+
+        ApproovService.setBindingHeader(header: "Authorization")
+        ApproovService.addSubstitutionHeader(header: "Api-Key", prefix: nil)
+        ApproovService.addSubstitutionQueryParam(key: "api_key")
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseAccountMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "\(targetURLString)?api_key=query-key")))
+        request.httpMethod = "GET"
+        request.setValue("Bearer oauth-token", forHTTPHeaderField: "Authorization")
+        request.setValue("header-key", forHTTPHeaderField: "Api-Key")
+
+        let signedRequest = try ApproovService.signRequest(request)
+
+        XCTAssertTrue(try XCTUnwrap(signedRequest.url?.absoluteString).contains("api_key=query-secret"))
+        XCTAssertEqual(signedRequest.value(forHTTPHeaderField: "Authorization"), "Bearer oauth-token")
+        XCTAssertEqual(signedRequest.value(forHTTPHeaderField: "Api-Key"), "header-secret")
+        let token = try XCTUnwrap(signedRequest.value(forHTTPHeaderField: "Approov-Token"))
+        XCTAssertFalse(token.isEmpty)
+        XCTAssertNotNil(signedRequest.value(forHTTPHeaderField: "Approov-TraceID"))
+        XCTAssertTrue(try XCTUnwrap(signedRequest.value(forHTTPHeaderField: "Signature-Input")).hasPrefix("account="))
+        XCTAssertTrue(try XCTUnwrap(signedRequest.value(forHTTPHeaderField: "Signature")).hasPrefix("account="))
+
+        let payload = try XCTUnwrap(decodeJWTBody(token))
+        XCTAssertEqual(payload["pay"] as? String, sha256Base64("Bearer oauth-token"))
+
+        let reply = fetchPlainNetworkReply(for: signedRequest)
+        XCTAssertEqual(getHeader(from: reply, key: "Api-Key"), "header-secret")
+        XCTAssertNotNil(getHeader(from: reply, key: "Approov-Token"))
+        XCTAssertNotNil(getHeader(from: reply, key: "Signature"))
+        let urlFromReply = try XCTUnwrap(reply?["url"] as? String)
+        XCTAssertTrue(urlFromReply.contains("api_key=query-secret"))
+    }
+
+    /// §2 Public Request Signing
+    ///
+    /// signRequest() should return the original request unchanged when the
+    /// service-layer decision is ShouldIgnore.
+    func testSignRequestReturnsOriginalRequestForIgnoredURL() throws {
+        try reinitializeServiceWithTargetHost()
+
+        var request = URLRequest(url: try XCTUnwrap(URL(string: unprotectedURLString)))
+        request.setValue("original", forHTTPHeaderField: "X-Test")
+
+        let signedRequest = try ApproovService.signRequest(request)
+
+        XCTAssertEqual(signedRequest.url, request.url)
+        XCTAssertEqual(signedRequest.allHTTPHeaderFields, request.allHTTPHeaderFields)
+        XCTAssertNil(signedRequest.value(forHTTPHeaderField: "Approov-Token"))
+        XCTAssertNil(signedRequest.value(forHTTPHeaderField: "Approov-TraceID"))
+    }
+
+    /// §2 Public Request Signing
+    ///
+    /// signRequest() should surface retryable token fetch failures as
+    /// networking errors.
+    func testSignRequestThrowsNetworkingErrorForRetryDecision() throws {
+        try reinitializeServiceWithTargetHost()
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "NO_NETWORK"
+              }
+            }
+            """
+        )
+
+        let request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+
+        XCTAssertThrowsError(try ApproovService.signRequest(request)) { error in
+            guard case let ApproovError.networkingError(message) = error else {
+                return XCTFail("Expected networkingError, got \(error)")
+            }
+            XCTAssertTrue(message.contains("no network"), "Unexpected message: \(message)")
+        }
+    }
+
+    /// §2 Public Request Signing
+    ///
+    /// signRequest() should surface fail-closed token fetch failures as
+    /// permanent errors.
+    func testSignRequestThrowsPermanentErrorForFailDecision() throws {
+        try reinitializeServiceWithTargetHost()
+        setDirective(
+            """
+            {
+              "operation": "fetchApproovToken",
+              "response": {
+                "status": "REJECTED"
+              }
+            }
+            """
+        )
+
+        let request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+
+        XCTAssertThrowsError(try ApproovService.signRequest(request)) { error in
+            guard case let ApproovError.permanentError(message) = error else {
+                return XCTFail("Expected permanentError, got \(error)")
+            }
+            XCTAssertTrue(message.contains("rejected"), "Unexpected message: \(message)")
+        }
+    }
+
     // MARK: - §3 Service Mutators & Decision Overrides
     // TESTING_REQUIREMENTS.md §3
 
@@ -858,6 +987,26 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
 
         let configuration = URLSessionConfiguration.ephemeral
         let session = ApproovURLSession(configuration: configuration)
+        let task = session.dataTask(with: request) { data, _, _ in
+            receivedData = data
+            expectation.fulfill()
+        }
+        task.resume()
+
+        waitForExpectations(timeout: 5.0)
+
+        guard let data = receivedData,
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return obj
+    }
+
+    private func fetchPlainNetworkReply(for request: URLRequest) -> [String: Any]? {
+        let expectation = self.expectation(description: "plain network request")
+        var receivedData: Data?
+
+        let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
         let task = session.dataTask(with: request) { data, _, _ in
             receivedData = data
             expectation.fulfill()


### PR DESCRIPTION
## Description

This PR adds a new public convenience method and fixes access control on the update response struct, enabling Approov protection for HTTP transports that cannot use `ApproovURLSession` directly.

### New: `signRequest(_:sessionConfig:)`

Added a convenience method on `ApproovService` that applies full Approov protection to a `URLRequest` and returns the protected request directly. This is designed for HTTP transports that own their own `URLSession` (e.g. Apollo iOS, gRPC-Swift) where substituting `ApproovURLSession` is not possible.

The method internally calls `updateRequestWithApproov` and interprets the decision:
- `.ShouldProceed` → returns the updated (protected) request
- `.ShouldIgnore` → returns the original request unchanged
- `.ShouldRetry` → throws `ApproovError.networkingError`
- `.ShouldFail` → throws the underlying error

The returned request includes:
- ✅ Approov token (`Approov-Token` header)
- ✅ Trace ID header
- ✅ Header and query parameter substitutions
- ✅ Message signing (when a signing mutator is configured)
- ⚠️ **No dynamic TLS pinning** — documented caveat in REFERENCE.md

### Changed: `ApproovUpdateResponse` access control

Made all members of `ApproovUpdateResponse` (`request`, `decision`, `sdkMessage`, `error`) `public`. Previously they had `internal` access, preventing external modules from reading the response fields returned by `updateRequestWithApproov`.

### Documentation

- Added `signRequest` section to REFERENCE.md with usage examples
- Added dynamic pinning caveat explaining that consumers must implement certificate pinning separately when using a plain `URLSession`
- Updated CHANGELOG.md with 3.5.10 entry

## Files Changed

| File | Change |
|:---|:---|
| `Sources/ApproovURLSession/ApproovService.swift` | `signRequest` method + `ApproovUpdateResponse` public access |
| `REFERENCE.md` | New signRequest section with pinning caveat |
| `CHANGELOG.md` | 3.5.10 entry |
| `Package.swift` | Version bump |
| `ApproovURLSession.podspec` | Version bump |

Related: approov/core-project-approov#561
