### PR TITLE
fix: message-signing fail-open (#564), version telemetry & auto-tagging

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -201,7 +201,8 @@ jobs:
   # Release placeholder check (verification ONLY — never tags).
   #
   # On every push / PR this asserts that:
-  #   - CHANGELOG.md has a top version header (## [x.y.z]); and
+  #   - CHANGELOG.md has a top version header (## [x.y.z]);
+  #   - that top version has not already been tagged; and
   #   - the "dev" release placeholders are present, so branches cut from main
   #     inherit them: Package.swift releaseTAG = "dev", every root .podspec
   #     s.version = "dev", and the setUserProperty telemetry string approov-service-urlsession/dev.
@@ -214,7 +215,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Verify CHANGELOG entry and dev placeholders
+      - name: Verify CHANGELOG entry, tag availability and dev placeholders
         run: |
           set -uo pipefail
           VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
@@ -224,6 +225,12 @@ jobs:
           fi
           echo "CHANGELOG top version: $VERSION"
           fail=0
+
+          git fetch --tags --quiet
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::CHANGELOG top version $VERSION is already tagged. Add a new top CHANGELOG version before merging more release changes."
+            fail=1
+          fi
 
           if ! grep -qF 'releaseTAG = "dev"' Package.swift; then
             echo "::error::Package.swift is missing the releaseTAG = \"dev\" placeholder (must stay in main)"
@@ -248,10 +255,10 @@ jobs:
           done
 
           if [ "$fail" -ne 0 ]; then
-            echo "::error::Release placeholders missing. main must keep the dev placeholders so branches inherit them; the release job stamps them at tag time."
+            echo "::error::Release verification failed. main must keep dev placeholders and the top CHANGELOG version must be untagged until the manual release job stamps it."
             exit 1
           fi
-          echo "OK: CHANGELOG version $VERSION present and dev placeholders intact. Tagging is manual (Actions -> Release)."
+          echo "OK: CHANGELOG version $VERSION is untagged and dev placeholders are intact. Tagging is manual (Actions -> Release)."
 
   # ---------------------------------------------------------------------------
   # Manual release (workflow_dispatch ONLY — the single place that tags).

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -195,3 +195,80 @@ jobs:
 
           sys.exit(0 if overall_ok else 1)
           EOF
+
+  # ---------------------------------------------------------------------------
+  # Automatic release tagging (main only). Runs only after build-and-test
+  # passes. The CHANGELOG top entry drives the version, which is stamped in
+  # lock-step into BOTH package manifests — Package.swift (releaseTAG) and the
+  # CocoaPods ApproovURLSession.podspec (s.version) — plus the runtime
+  # user-property string, before the release commit is tagged. main keeps the
+  # "dev" placeholders; each release tag carries the stamped version. Skipped
+  # if the tag already exists.
+  # ---------------------------------------------------------------------------
+  tag-release:
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract Version from CHANGELOG
+        id: get-version
+        run: |
+          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not find a version header (## [x.y.z]) in CHANGELOG.md"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version extracted from CHANGELOG.md is: $VERSION"
+
+      - name: Create and Push Tag
+        run: |
+          VERSION="${{ steps.get-version.outputs.VERSION }}"
+
+          if git fetch origin "refs/tags/$VERSION" --quiet 2>/dev/null; then
+            echo "Tag $VERSION already exists. Skipping tagging."
+            exit 0
+          fi
+
+          echo "Tag $VERSION does not exist. Verifying dev placeholder..."
+          FILE="Sources/ApproovURLSession/ApproovService.swift"
+          if ! grep -q 'approov-service-urlsession/dev' "$FILE"; then
+            echo "::error::Could not find 'approov-service-urlsession/dev' in $FILE"
+            exit 1
+          fi
+
+          echo "Stamping version $VERSION into the SwiftPM and CocoaPods package files..."
+          # 1. Runtime user-property string (telemetry)
+          perl -pi -e "s|approov-service-urlsession/dev|approov-service-urlsession/$VERSION|g" "$FILE"
+          # 2. SwiftPM: Package.swift releaseTAG marker
+          perl -pi -e "s|releaseTAG = \"dev\"|releaseTAG = \"$VERSION\"|g" Package.swift
+          # 3. CocoaPods: the root podspec(s) — the s.version literal and any dev user-property string
+          shopt -s nullglob
+          for PODSPEC in *.podspec; do
+            echo "Stamping version $VERSION into $PODSPEC..."
+            perl -pi -e "s|(\bs(?:pec)?\.version\s*=\s*['\"])[^'\"]*(['\"])|\${1}$VERSION\${2}|g" "$PODSPEC"
+            perl -pi -e "s|approov-service-urlsession/dev|approov-service-urlsession/$VERSION|g" "$PODSPEC"
+          done
+          shopt -u nullglob
+
+          # Defensive: refuse to tag if any package file still carries the dev placeholder.
+          if grep -q 'releaseTAG = "dev"' Package.swift || grep -Eq 's\.version[[:space:]]*=[[:space:]]*"dev"' ./*.podspec; then
+            echo "::error::A dev placeholder was not replaced; aborting tag."
+            exit 1
+          fi
+
+          echo "Configuring git and committing release modifications..."
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Release version $VERSION"
+
+          echo "Creating and pushing tag $VERSION..."
+          git tag "$VERSION"
+          git push origin "$VERSION"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,7 @@ name: Build and Test
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -197,17 +198,75 @@ jobs:
           EOF
 
   # ---------------------------------------------------------------------------
-  # Automatic release tagging (main only). Runs only after build-and-test
-  # passes. The CHANGELOG top entry drives the version, which is stamped in
-  # lock-step into BOTH package manifests — Package.swift (releaseTAG) and the
-  # CocoaPods ApproovURLSession.podspec (s.version) — plus the runtime
-  # user-property string, before the release commit is tagged. main keeps the
-  # "dev" placeholders; each release tag carries the stamped version. Skipped
-  # if the tag already exists.
+  # Release placeholder check (verification ONLY — never tags).
+  #
+  # On every push / PR this asserts that:
+  #   - CHANGELOG.md has a top version header (## [x.y.z]); and
+  #   - the "dev" release placeholders are present, so branches cut from main
+  #     inherit them: Package.swift releaseTAG = "dev", every root .podspec
+  #     s.version = "dev", and the setUserProperty telemetry string approov-service-urlsession/dev.
+  # Tagging is a SEPARATE, manual step (the release job below), so any issue
+  # found after merge but before tagging can still be fixed on main first.
   # ---------------------------------------------------------------------------
-  tag-release:
+  verify-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Verify CHANGELOG entry and dev placeholders
+        run: |
+          set -uo pipefail
+          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version header (## [x.y.z]) found in CHANGELOG.md"
+            exit 1
+          fi
+          echo "CHANGELOG top version: $VERSION"
+          fail=0
+
+          if ! grep -qF 'releaseTAG = "dev"' Package.swift; then
+            echo "::error::Package.swift is missing the releaseTAG = \"dev\" placeholder (must stay in main)"
+            grep -nE 'releaseTAG[[:space:]]*=' Package.swift || true
+            fail=1
+          fi
+
+          SRC="Sources/ApproovURLSession/ApproovService.swift"
+          if ! grep -qF "approov-service-urlsession/dev" "$SRC"; then
+            echo "::error::$SRC is missing the approov-service-urlsession/dev telemetry placeholder (must stay in main)"
+            grep -nE 'setUserProperty' "$SRC" || true
+            fail=1
+          fi
+
+          for p in *.podspec; do
+            [ -e "$p" ] || continue
+            if ! grep -qE '\.version[[:space:]]*=[[:space:]]*"dev"' "$p"; then
+              echo "::error::$p is missing the s.version = \"dev\" placeholder (must stay in main)"
+              grep -nE '\.version[[:space:]]*=' "$p" || true
+              fail=1
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Release placeholders missing. main must keep the dev placeholders so branches inherit them; the release job stamps them at tag time."
+            exit 1
+          fi
+          echo "OK: CHANGELOG version $VERSION present and dev placeholders intact. Tagging is manual (Actions -> Release)."
+
+  # ---------------------------------------------------------------------------
+  # Manual release (workflow_dispatch ONLY — the single place that tags).
+  #
+  # Trigger from the Actions tab against main once main is known good. Gated on
+  # build-and-test so a release never tags failing code. It stamps the CHANGELOG
+  # version in lock-step into the dev placeholders (Package.swift releaseTAG,
+  # every root .podspec s.version, and the approov-service-urlsession/dev telemetry string),
+  # commits "Release version <x.y.z>", and tags THAT commit. main keeps the dev
+  # placeholders (the release commit is not pushed to main, only the tag ref);
+  # the tag carries the stamped version. Skipped if the tag already exists.
+  # ---------------------------------------------------------------------------
+  release:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs: build-and-test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -228,8 +287,9 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version extracted from CHANGELOG.md is: $VERSION"
 
-      - name: Create and Push Tag
+      - name: Stamp version, commit and tag
         run: |
+          set -uo pipefail
           VERSION="${{ steps.get-version.outputs.VERSION }}"
 
           if git fetch origin "refs/tags/$VERSION" --quiet 2>/dev/null; then
@@ -237,38 +297,36 @@ jobs:
             exit 0
           fi
 
-          echo "Tag $VERSION does not exist. Verifying dev placeholder..."
-          FILE="Sources/ApproovURLSession/ApproovService.swift"
-          if ! grep -q 'approov-service-urlsession/dev' "$FILE"; then
-            echo "::error::Could not find 'approov-service-urlsession/dev' in $FILE"
+          SRC="Sources/ApproovURLSession/ApproovService.swift"
+          if ! grep -qF "approov-service-urlsession/dev" "$SRC"; then
+            echo "::error::Could not find 'approov-service-urlsession/dev' placeholder in $SRC"
             exit 1
           fi
 
-          echo "Stamping version $VERSION into the SwiftPM and CocoaPods package files..."
-          # 1. Runtime user-property string (telemetry)
-          perl -pi -e "s|approov-service-urlsession/dev|approov-service-urlsession/$VERSION|g" "$FILE"
-          # 2. SwiftPM: Package.swift releaseTAG marker
+          echo "Stamping version $VERSION into manifests and telemetry..."
+          perl -pi -e "s|approov-service-urlsession/dev|approov-service-urlsession/$VERSION|g" "$SRC"
           perl -pi -e "s|releaseTAG = \"dev\"|releaseTAG = \"$VERSION\"|g" Package.swift
-          # 3. CocoaPods: the root podspec(s) — the s.version literal and any dev user-property string
-          shopt -s nullglob
           for PODSPEC in *.podspec; do
+            [ -e "$PODSPEC" ] || continue
             echo "Stamping version $VERSION into $PODSPEC..."
-            perl -pi -e "s|(\bs(?:pec)?\.version\s*=\s*['\"])[^'\"]*(['\"])|\${1}$VERSION\${2}|g" "$PODSPEC"
-            perl -pi -e "s|approov-service-urlsession/dev|approov-service-urlsession/$VERSION|g" "$PODSPEC"
+            perl -pi -e "s|(\bs(?:pec)?\.version\s*=\s*['\"])dev(['\"])|\${1}$VERSION\${2}|g" "$PODSPEC"
           done
-          shopt -u nullglob
 
-          # Defensive: refuse to tag if any package file still carries the dev placeholder.
-          if grep -q 'releaseTAG = "dev"' Package.swift || grep -Eq 's\.version[[:space:]]*=[[:space:]]*"dev"' ./*.podspec; then
+          # Defensive: refuse to tag if any dev placeholder survived.
+          leftover=0
+          grep -q 'releaseTAG = "dev"' Package.swift && leftover=1
+          grep -qF "approov-service-urlsession/dev" "$SRC" && leftover=1
+          for PODSPEC in *.podspec; do
+            [ -e "$PODSPEC" ] || continue
+            grep -Eq 's\.version[[:space:]]*=[[:space:]]*"dev"' "$PODSPEC" && leftover=1
+          done
+          if [ "$leftover" -ne 0 ]; then
             echo "::error::A dev placeholder was not replaced; aborting tag."
             exit 1
           fi
 
-          echo "Configuring git and committing release modifications..."
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Release version $VERSION"
-
-          echo "Creating and pushing tag $VERSION..."
           git tag "$VERSION"
           git push origin "$VERSION"

--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -1,6 +1,8 @@
 Pod::Spec.new do |s|
   s.name         = "ApproovURLSession"
-  s.version      = "3.5.10"
+  # "dev" placeholder — replaced with the CHANGELOG version by the tag-release CI job at release
+  # time (in lock-step with Package.swift releaseTAG and the runtime user-property string).
+  s.version      = "dev"
   s.summary      = "Approov mobile attestation SDK"
   s.description  = <<-DESC
     Approov SDK integrates security attestation and secure string fetching for both iOS and watchOS apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ## [3.5.10] - 2026-06-08
 
 ### Added
+- Automatic release tagging on merge to `main` (`tag-release` job in `build_and_test.yml`): once the build/tests pass, the top CHANGELOG entry drives a matching git tag and the version is stamped in lock-step into `Package.swift` (`releaseTAG`), the CocoaPods `ApproovURLSession.podspec` (`s.version`), and the runtime user-property string, before the release commit is tagged. `main` keeps the `dev` placeholders; each tag carries the stamped version. Skipped if the tag already exists.
+- The runtime Approov user-property now reports the service-layer version (`approov-service-urlsession/<version>`); previously a bare, version-less string was reported.
 - New `signRequest(_:sessionConfig:)` convenience method on `ApproovService` that applies Approov protection (token, substitutions, and message signing when configured) to a `URLRequest` and returns the protected request directly. Designed for HTTP transports that own their own `URLSession` (e.g. Apollo iOS, gRPC-Swift) where substituting `ApproovURLSession` is not possible.
 
 ### Changed
@@ -14,6 +16,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - `initialize(config:comment:)` now resets `serviceMutator` and `useApproovStatusIfNoToken` to defaults on each successful call, alongside the existing resets of substitution headers, exclusion regexes, and binding header.
 
 ### Fixed
+- Message signing now conforms to the cross-layer fail-open policy (core-project-approov#564). An ES256 ASN.1/DER decode failure and a `Signature`/`Signature-Input` serialization failure now log at error level and proceed **unsigned** instead of aborting the request, matching the existing install/account/base64 fail-open paths. The ES256 ASN.1/DER decoder is now bounds-checked so a malformed or truncated signature throws (and fails open) rather than risking an out-of-bounds trap. Only a required body digest that cannot be generated and an unsupported signing algorithm still fail closed.
 - `PinningURLSessionDelegate`: In empty-config bypass mode, the challenge handler now calls `.performDefaultHandling` rather than accepting the server trust via `.useCredential`. This ensures OS-level certificate validation always runs even when Approov dynamic pinning is skipped.
 
 ## [3.5.9] - 2026-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to this package will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [3.5.11] - 2026-06-24
+
+### Added
+- Manual release stamping via `workflow_dispatch` (`release` job in `build_and_test.yml`): once the build/tests pass, the top CHANGELOG entry drives a matching git tag and the version is stamped in lock-step into `Package.swift` (`releaseTAG`), the CocoaPods `ApproovURLSession.podspec` (`s.version`), and the runtime user-property string before the release commit is tagged. `main` keeps the `dev` placeholders; each tag carries the stamped version.
+- The runtime Approov user-property now reports the service-layer version (`approov-service-urlsession/<version>`); previously a bare, version-less string was reported.
+
+### Fixed
+- Message signing now conforms to the cross-layer fail-open policy (core-project-approov#564). An ES256 ASN.1/DER decode failure and a `Signature`/`Signature-Input` serialization failure now log at error level and proceed **unsigned** instead of aborting the request, matching the existing install/account/base64 fail-open paths. The ES256 ASN.1/DER decoder is now bounds-checked so a malformed or truncated signature throws (and fails open) rather than risking an out-of-bounds trap. Only a required body digest that cannot be generated and an unsupported signing algorithm still fail closed.
+
 ## [3.5.10] - 2026-06-08
 
 ### Added
-- Automatic release tagging on merge to `main` (`tag-release` job in `build_and_test.yml`): once the build/tests pass, the top CHANGELOG entry drives a matching git tag and the version is stamped in lock-step into `Package.swift` (`releaseTAG`), the CocoaPods `ApproovURLSession.podspec` (`s.version`), and the runtime user-property string, before the release commit is tagged. `main` keeps the `dev` placeholders; each tag carries the stamped version. Skipped if the tag already exists.
-- The runtime Approov user-property now reports the service-layer version (`approov-service-urlsession/<version>`); previously a bare, version-less string was reported.
 - New `signRequest(_:sessionConfig:)` convenience method on `ApproovService` that applies Approov protection (token, substitutions, and message signing when configured) to a `URLRequest` and returns the protected request directly. Designed for HTTP transports that own their own `URLSession` (e.g. Apollo iOS, gRPC-Swift) where substituting `ApproovURLSession` is not possible.
 
 ### Changed
@@ -16,7 +23,6 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - `initialize(config:comment:)` now resets `serviceMutator` and `useApproovStatusIfNoToken` to defaults on each successful call, alongside the existing resets of substitution headers, exclusion regexes, and binding header.
 
 ### Fixed
-- Message signing now conforms to the cross-layer fail-open policy (core-project-approov#564). An ES256 ASN.1/DER decode failure and a `Signature`/`Signature-Input` serialization failure now log at error level and proceed **unsigned** instead of aborting the request, matching the existing install/account/base64 fail-open paths. The ES256 ASN.1/DER decoder is now bounds-checked so a malformed or truncated signature throws (and fails open) rather than risking an out-of-bounds trap. Only a required body digest that cannot be generated and an unsupported signing algorithm still fail closed.
 - `PinningURLSessionDelegate`: In empty-config bypass mode, the challenge handler now calls `.performDefaultHandling` rather than accepting the server trust via `.useCredential`. This ensures OS-level certificate validation always runs even when Approov dynamic pinning is skipped.
 
 ## [3.5.9] - 2026-06-02

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,10 @@
 // swift-tools-version:5.8
 import Foundation
 import PackageDescription
-// The release tag for this version of ApproovURLSession
-let releaseTAG = "3.5.10"
+// The release tag for this version of ApproovURLSession — "dev" for local/CI builds; replaced
+// with the CHANGELOG version by the tag-release CI job at release time (in lock-step with the
+// podspec s.version and the runtime user-property string).
+let releaseTAG = "dev"
 // SDK package version (used for both iOS and watchOS)
 let sdkVersion: Version = "3.5.3"
 let useMiniSDK = ProcessInfo.processInfo.environment["APPROOV_USE_MINI_SDK"] == "1"

--- a/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
@@ -137,73 +137,86 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                 return request
             }
 
-            // Build the signature base
-            let baseBuilder = SignatureBaseBuilder(sigParams: params, ctx: provider)
-            let message = try baseBuilder.createSignatureBase()
-            // WARNING never log the message as it contains an Approov token which provides access to your API.
+            // Unsupported signing algorithm is a developer misconfiguration: fail closed
+            // (propagate) so it surfaces immediately, and is checked before the fail-open block
+            // below so it cannot be swallowed.
+            let alg = params.getAlg()
+            guard alg == ApproovDefaultMessageSigning.ALG_ES256 || alg == ApproovDefaultMessageSigning.ALG_HS256 else {
+                throw ApproovError.permanentError(message: "Unsupported algorithm identifier: \(alg ?? "unknown")")
+            }
 
-            // Generate the signature
-            let sigId: String
-            let signature: Data
-            switch params.getAlg() {
-            case ApproovDefaultMessageSigning.ALG_ES256:
-                sigId = "install"
-                guard let base64Signature = ApproovService.getInstallMessageSignature(message: message),
-                      let decodedSignature = Data(base64Encoded: base64Signature) else {
-                    if ApproovService.loggingLevel >= .error {
-                        os_log("ApproovService: install message signature unavailable, skipping signing", type: .error)
+            // Message signing is fail-open from here (core-project-approov#564): any failure to
+            // build the signature base, obtain/decode the SDK signature, decode the ES256
+            // ASN.1/DER signature, or serialize the headers logs at error level and proceeds
+            // UNSIGNED. The only fail-closed cases are a required body digest that cannot be
+            // generated (handled in buildSignatureParameters above) and an unsupported algorithm
+            // (checked above). The backend remains the enforcement point for message signatures.
+            do {
+                // Build the signature base
+                let baseBuilder = SignatureBaseBuilder(sigParams: params, ctx: provider)
+                let message = try baseBuilder.createSignatureBase()
+                // WARNING never log the message as it contains an Approov token which provides access to your API.
+
+                // Generate the signature
+                let sigId: String
+                let signature: Data
+                if alg == ApproovDefaultMessageSigning.ALG_ES256 {
+                    sigId = "install"
+                    guard let base64Signature = ApproovService.getInstallMessageSignature(message: message),
+                          let decodedSignature = Data(base64Encoded: base64Signature) else {
+                        if ApproovService.loggingLevel >= .error {
+                            os_log("ApproovService: install message signature unavailable, skipping signing", type: .error)
+                        }
+                        return request
                     }
-                    return request
-                }
-                // decode the signature from ASN.1 DER format
-                signature = try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(decodedSignature)
-            case ApproovDefaultMessageSigning.ALG_HS256:
-                sigId = "account"
-                guard let base64Signature = ApproovService.getAccountMessageSignature(message: message),
-                      let decodedSignature = Data(base64Encoded: base64Signature) else {
-                    if ApproovService.loggingLevel >= .error {
-                        os_log("ApproovService: account message signature unavailable, skipping signing", type: .error)
-                    }
-                    return request
-                }
-                signature = decodedSignature
-            default:
-                throw ApproovError.permanentError(message: "Unsupported algorithm identifier: \(params.getAlg() ?? "unknown")")
-            }
-
-            // Create signature headers
-            guard let sigHeader = try SFV.serializeDictionary(key: sigId, data: signature) else {
-                throw ApproovError.permanentError(message: "Failed to serialize signature header")
-            }
-            guard let sigInputHeader = try SFV.serializeDictionary(key: sigId, innerList: params.toComponentValue()) else {
-                throw ApproovError.permanentError(message: "Failed to serialize signature input header")
-            }
-
-            // Debugging - log the message and signature-related headers
-            // WARNING never log the message in production code as it contains the Approov token which allows API access
-            // os_log("Message Value - Signature Message: %@", type: .debug, message)
-            // os_log("Message Header - Signature: %@", type: .debug, sigHeader)
-            // os_log("Message Header Signature-Input: %@", type: .debug, sigInputHeader)
-
-            // Add headers to the request
-            var signedRequest = provider.getRequest()
-            signedRequest.addValue(sigHeader, forHTTPHeaderField: "Signature")
-            signedRequest.addValue(sigInputHeader, forHTTPHeaderField: "Signature-Input")
-
-            if params.isDebugMode() {
-                let digest = ApproovDefaultMessageSigning.sha256(data: Data(message.utf8))
-                if let sigBaseDigestHeader = try SFV.serializeDictionary(key: "sha-256", data: digest) {
-                    signedRequest.addValue(sigBaseDigestHeader, forHTTPHeaderField: "Signature-Base-Digest")
+                    // decode the signature from ASN.1 DER format (a malformed signature fails open via the catch)
+                    signature = try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(decodedSignature)
                 } else {
-                    if ApproovService.loggingLevel >= .debug {
+                    sigId = "account"
+                    guard let base64Signature = ApproovService.getAccountMessageSignature(message: message),
+                          let decodedSignature = Data(base64Encoded: base64Signature) else {
+                        if ApproovService.loggingLevel >= .error {
+                            os_log("ApproovService: account message signature unavailable, skipping signing", type: .error)
+                        }
+                        return request
+                    }
+                    signature = decodedSignature
+                }
+
+                // Create signature headers. A serialization failure (thrown or nil) fails open.
+                guard let sigHeader = try SFV.serializeDictionary(key: sigId, data: signature),
+                      let sigInputHeader = try SFV.serializeDictionary(key: sigId, innerList: params.toComponentValue()) else {
+                    if ApproovService.loggingLevel >= .error {
+                        os_log("ApproovService: failed to serialize signature headers, skipping signing", type: .error)
+                    }
+                    return request
+                }
+
+                // Add headers to the request
+                var signedRequest = provider.getRequest()
+                signedRequest.addValue(sigHeader, forHTTPHeaderField: "Signature")
+                signedRequest.addValue(sigInputHeader, forHTTPHeaderField: "Signature-Input")
+
+                if params.isDebugMode() {
+                    let digest = ApproovDefaultMessageSigning.sha256(data: Data(message.utf8))
+                    // The optional debug digest header must not drop a valid signature on failure.
+                    if let sigBaseDigestHeader = (try? SFV.serializeDictionary(key: "sha-256", data: digest)) ?? nil {
+                        signedRequest.addValue(sigBaseDigestHeader, forHTTPHeaderField: "Signature-Base-Digest")
+                    } else if ApproovService.loggingLevel >= .debug {
                         os_log("ApproovService: Failed to get digest algorithm - no debug entry", type: .debug)
                     }
                 }
-            }
 
-            // WARNING never log the full request as it contains an Approov token which provides access to your API
-            // os_log("Request String: %@", type: .debug, "\(signedRequest)")
-            return signedRequest
+                // WARNING never log the full request as it contains an Approov token which provides access to your API
+                return signedRequest
+            } catch {
+                // Fail open: building the signature base, decoding the ES256 ASN.1/DER signature,
+                // or serializing the headers failed. Log at error and proceed unsigned.
+                if ApproovService.loggingLevel >= .error {
+                    os_log("ApproovService: message signing failed, proceeding unsigned: %@", type: .error, error.localizedDescription)
+                }
+                return request
+            }
         }
 
         return request
@@ -225,48 +238,56 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
 
     // Decode ASN.1 DER encoded ES256 signature into "raw" signature format
     private static func decodeASN_1_DER_ES256_Signature(_ signature: Data) throws -> Data {
+        // Work over a 0-based byte array so indexing is safe regardless of any Data slice bounds,
+        // and read through a bounds-checked helper so malformed/truncated input THROWS (and is
+        // handled fail-open by the caller) rather than triggering an out-of-bounds trap/crash.
+        let bytes = [UInt8](signature)
         var offset = 0
 
+        func nextByte() throws -> Int {
+            guard offset < bytes.count else {
+                throw ApproovError.permanentError(message: "Truncated ASN.1 DER signature")
+            }
+            let value = Int(bytes[offset])
+            offset += 1
+            return value
+        }
+
         // Ensure the signature starts with a valid ASN.1 sequence
-        guard signature[offset] == 0x30 else {
+        guard try nextByte() == 0x30 else {
             throw ApproovError.permanentError(message: "Invalid ASN.1 DER sequence")
         }
-        offset += 1
 
         // Read the total length of the sequence
-        let sequenceLength = Int(signature[offset])
-        offset += 1
-
-        guard sequenceLength == signature.count - 2 else {
+        let sequenceLength = try nextByte()
+        guard sequenceLength == bytes.count - 2 else {
             throw ApproovError.permanentError(message: "Invalid ASN.1 DER sequence length")
         }
 
         // Decode the first integer (r)
-        guard signature[offset] == 0x02 else {
+        guard try nextByte() == 0x02 else {
             throw ApproovError.permanentError(message: "Invalid ASN.1 DER integer for r")
         }
-        offset += 1
-
-        let rLength = Int(signature[offset])
-        offset += 1
-
-        let rBytes = signature[offset..<(offset + rLength)]
+        let rLength = try nextByte()
+        guard rLength > 0, offset + rLength <= bytes.count else {
+            throw ApproovError.permanentError(message: "Invalid ASN.1 DER length for r")
+        }
+        let rBytes = Data(bytes[offset..<(offset + rLength)])
         offset += rLength
 
         // Decode the second integer (s)
-        guard signature[offset] == 0x02 else {
+        guard try nextByte() == 0x02 else {
             throw ApproovError.permanentError(message: "Invalid ASN.1 DER integer for s")
         }
-        offset += 1
-
-        let sLength = Int(signature[offset])
-        offset += 1
-
-        let sBytes = signature[offset..<(offset + sLength)]
+        let sLength = try nextByte()
+        guard sLength > 0, offset + sLength <= bytes.count else {
+            throw ApproovError.permanentError(message: "Invalid ASN.1 DER length for s")
+        }
+        let sBytes = Data(bytes[offset..<(offset + sLength)])
         offset += sLength
 
         // Ensure the entire signature has been processed
-        guard offset == signature.count else {
+        guard offset == bytes.count else {
             throw ApproovError.permanentError(message: "Extra data in ASN.1 DER signature")
         }
 

--- a/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
@@ -56,6 +56,9 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
      */
     private var hostFactories: [String: SignatureParametersFactory]
 
+    private var installMessageSignatureProviderForTesting: ((String) -> String?)?
+    private var accountMessageSignatureProviderForTesting: ((String) -> String?)?
+
     /**
      * Initializer
      */
@@ -89,6 +92,28 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
     public func putHostFactory(hostName: String, factory: SignatureParametersFactory) -> ApproovDefaultMessageSigning {
         hostFactories[hostName] = factory
         return self
+    }
+
+    func setInstallMessageSignatureProviderForTesting(_ provider: ((String) -> String?)?) -> ApproovDefaultMessageSigning {
+        installMessageSignatureProviderForTesting = provider
+        return self
+    }
+
+    func setAccountMessageSignatureProviderForTesting(_ provider: ((String) -> String?)?) -> ApproovDefaultMessageSigning {
+        accountMessageSignatureProviderForTesting = provider
+        return self
+    }
+
+    func getInstallMessageSignature(message: String) -> String? {
+        return installMessageSignatureProviderForTesting?(message) ?? ApproovService.getInstallMessageSignature(message: message)
+    }
+
+    func getAccountMessageSignature(message: String) -> String? {
+        return accountMessageSignatureProviderForTesting?(message) ?? ApproovService.getAccountMessageSignature(message: message)
+    }
+
+    func decodeBase64Signature(_ base64Signature: String) -> Data? {
+        return Data(base64Encoded: base64Signature)
     }
 
     /**
@@ -162,8 +187,8 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                 let signature: Data
                 if alg == ApproovDefaultMessageSigning.ALG_ES256 {
                     sigId = "install"
-                    guard let base64Signature = ApproovService.getInstallMessageSignature(message: message),
-                          let decodedSignature = Data(base64Encoded: base64Signature) else {
+                    guard let base64Signature = getInstallMessageSignature(message: message),
+                          let decodedSignature = decodeBase64Signature(base64Signature) else {
                         if ApproovService.loggingLevel >= .error {
                             os_log("ApproovService: install message signature unavailable, skipping signing", type: .error)
                         }
@@ -173,8 +198,8 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                     signature = try ApproovDefaultMessageSigning.decodeASN_1_DER_ES256_Signature(decodedSignature)
                 } else {
                     sigId = "account"
-                    guard let base64Signature = ApproovService.getAccountMessageSignature(message: message),
-                          let decodedSignature = Data(base64Encoded: base64Signature) else {
+                    guard let base64Signature = getAccountMessageSignature(message: message),
+                          let decodedSignature = decodeBase64Signature(base64Signature) else {
                         if ApproovService.loggingLevel >= .error {
                             os_log("ApproovService: account message signature unavailable, skipping signing", type: .error)
                         }

--- a/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
@@ -200,10 +200,10 @@ public class ApproovDefaultMessageSigning: ApproovServiceMutator, CustomStringCo
                 if params.isDebugMode() {
                     let digest = ApproovDefaultMessageSigning.sha256(data: Data(message.utf8))
                     // The optional debug digest header must not drop a valid signature on failure.
-                    if let sigBaseDigestHeader = (try? SFV.serializeDictionary(key: "sha-256", data: digest)) ?? nil {
+                    if let sigBaseDigestHeader = try? SFV.serializeDictionary(key: "sha-256", data: digest) {
                         signedRequest.addValue(sigBaseDigestHeader, forHTTPHeaderField: "Signature-Base-Digest")
                     } else if ApproovService.loggingLevel >= .debug {
-                        os_log("ApproovService: Failed to get digest algorithm - no debug entry", type: .debug)
+                        os_log("ApproovService: Failed to serialize Signature-Base-Digest header - no debug entry", type: .debug)
                     }
                 }
 

--- a/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
+++ b/Sources/ApproovURLSession/ApproovDefaultMessageSigning.swift
@@ -372,6 +372,7 @@ public class SignatureParametersFactory {
     private var addApproovTokenHeader: Bool = false
     private var addApproovTraceIDHeader: Bool = false
     private var optionalHeaders: [String] = []
+    private var algorithmOverrideForTesting: String?
 
     /**
      * Sets the base parameters for the factory.
@@ -424,6 +425,11 @@ public class SignatureParametersFactory {
      */
     public func setUseAccountMessageSigning() -> SignatureParametersFactory {
         self.useAccountMessageSigning = true
+        return self
+    }
+
+    func setAlgorithmOverrideForTesting(_ algorithm: String?) -> SignatureParametersFactory {
+        self.algorithmOverrideForTesting = algorithm
         return self
     }
 
@@ -498,7 +504,7 @@ public class SignatureParametersFactory {
         } else {
             requestParameters = SignatureParameters(base: baseParameters!) // Safe to unwrap, cannot be nil
         }
-        requestParameters.setAlg(useAccountMessageSigning ? ApproovDefaultMessageSigning.ALG_HS256 : ApproovDefaultMessageSigning.ALG_ES256)
+        requestParameters.setAlg(algorithmOverrideForTesting ?? (useAccountMessageSigning ? ApproovDefaultMessageSigning.ALG_HS256 : ApproovDefaultMessageSigning.ALG_ES256))
 
         if addCreated || expiresLifetime > 0 {
             let currentTime = Int64(Date().timeIntervalSince1970)

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -258,7 +258,8 @@ public class ApproovService {
             }
             serviceIsInitialized = true
             if !config.isEmpty {
-                Approov.setUserProperty("approov-service-urlsession")
+                // "dev" is a placeholder replaced with the release version by the tag-release CI job.
+                Approov.setUserProperty("approov-service-urlsession/dev")
             }
         }
     }

--- a/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -684,11 +684,13 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
     /// request. The request should proceed unsigned with earlier Approov
     /// mutations intact.
     func testAccountMessageSigningInvalidBase64FailsOpen() throws {
-        try reinitializeServiceWithTargetHost(scenarioBody: #""accountMessageSignatureMode": "invalid-base64""#)
+        try reinitializeServiceWithTargetHost()
 
         let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
             .setUseAccountMessageSigning()
-        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        let signer = ApproovDefaultMessageSigning()
+            .setAccountMessageSignatureProviderForTesting { _ in "not-base64" }
+            .setDefaultFactory(factory)
         ApproovService.setServiceMutator(signer)
 
         var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
@@ -707,12 +709,18 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
     /// inside the decoder, be caught by the fail-open signing policy, and allow
     /// the request to proceed unsigned.
     func testInstallMessageSigningMalformedDERFailsOpen() throws {
-        for signatureMode in ["malformed-der", "truncated-der"] {
-            try reinitializeServiceWithTargetHost(scenarioBody: #""installMessageSignatureMode": "\#(signatureMode)""#)
+        let malformedSignatures: [(String, Data)] = [
+            ("malformed-der", Data([0x31, 0x00])),
+            ("truncated-der", Data([0x30, 0x06, 0x02])),
+        ]
 
+        for (signatureMode, signature) in malformedSignatures {
+            try reinitializeServiceWithTargetHost()
             let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
                 .setUseInstallMessageSigning()
-            let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+            let signer = ApproovDefaultMessageSigning()
+                .setInstallMessageSignatureProviderForTesting { _ in signature.base64EncodedString() }
+                .setDefaultFactory(factory)
             ApproovService.setServiceMutator(signer)
 
             var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
@@ -1129,23 +1137,11 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
     /// Non-empty initialization should report the service layer name and current
     /// development placeholder version to the native SDK user-property.
     func testProtectedInitializationReportsVersionedUserProperty() throws {
-        XCTAssertEqual(MiniSDKAttesterProxyController.userProperty(), "approov-service-urlsession/dev")
-    }
+        try reinitializeServiceWithTargetHost()
+        let token = try ApproovService.fetchToken(url: targetURLString)
+        let payload = try XCTUnwrap(decodeJWTBody(token))
 
-    /// §8 Versioned Service-Layer Telemetry
-    ///
-    /// Empty-config bypass mode must not report protected-service telemetry
-    /// because the native SDK is not initialized for that service layer setup.
-    func testEmptyConfigInitializationDoesNotReportProtectedTelemetry() throws {
-        MiniSDKAttesterProxyController.clearUserProperty()
-        ApproovService.resetForTesting()
-        ApproovService.setLoggingLevel(.off)
-
-        try ApproovService.initialize(config: "", comment: "reinit-empty-config")
-
-        XCTAssertTrue(ApproovService.isInitialized())
-        XCTAssertFalse(ApproovService.isApproovEnabled())
-        XCTAssertNil(MiniSDKAttesterProxyController.userProperty())
+        XCTAssertEqual(payload["user_property"] as? String, "approov-service-urlsession/dev")
     }
 
     // MARK: - Test Helpers

--- a/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -678,6 +678,162 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
         XCTAssertNil(getHeader(from: protectedReply, key: "Signature-Input"))
     }
 
+    /// §5 Message Signature Fail-Open Coverage
+    ///
+    /// An invalid base64 account message signing result should not abort the
+    /// request. The request should proceed unsigned with earlier Approov
+    /// mutations intact.
+    func testAccountMessageSigningInvalidBase64FailsOpen() throws {
+        try reinitializeServiceWithTargetHost(scenarioBody: #""accountMessageSignatureMode": "invalid-base64""#)
+
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseAccountMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+        request.httpMethod = "GET"
+        let protectedReply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"))
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-TraceID"))
+        XCTAssertNil(getHeader(from: protectedReply, key: "Signature"))
+        XCTAssertNil(getHeader(from: protectedReply, key: "Signature-Input"))
+    }
+
+    /// §5 ES256 DER Decode Robustness
+    ///
+    /// Malformed and truncated ES256 ASN.1/DER install signatures should throw
+    /// inside the decoder, be caught by the fail-open signing policy, and allow
+    /// the request to proceed unsigned.
+    func testInstallMessageSigningMalformedDERFailsOpen() throws {
+        for signatureMode in ["malformed-der", "truncated-der"] {
+            try reinitializeServiceWithTargetHost(scenarioBody: #""installMessageSignatureMode": "\#(signatureMode)""#)
+
+            let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+                .setUseInstallMessageSigning()
+            let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+            ApproovService.setServiceMutator(signer)
+
+            var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+            request.httpMethod = "GET"
+            let protectedReply = fetchNetworkReply(for: request)
+
+            XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"), "Failed for \(signatureMode)")
+            XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-TraceID"), "Failed for \(signatureMode)")
+            XCTAssertNil(getHeader(from: protectedReply, key: "Signature"), "Failed for \(signatureMode)")
+            XCTAssertNil(getHeader(from: protectedReply, key: "Signature-Input"), "Failed for \(signatureMode)")
+        }
+    }
+
+    /// §5 Message Signature Fail-Open Coverage
+    ///
+    /// A signature-base construction failure should not abort the request. The
+    /// request should proceed with token and trace headers, but without partial
+    /// signature headers.
+    func testUpdateRequestMessageSigningFailsOpenWhenSignatureBaseCannotBeBuilt() throws {
+        try reinitializeServiceWithTargetHost()
+
+        let baseParameters = SignatureParameters()
+        _ = baseParameters.addComponentIdentifier("X-Required-Missing")
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory(baseParametersOverride: baseParameters)
+            .setUseAccountMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+        request.httpMethod = "GET"
+        let protectedReply = fetchNetworkReply(for: request)
+
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-Token"))
+        XCTAssertNotNil(getHeader(from: protectedReply, key: "Approov-TraceID"))
+        XCTAssertNil(getHeader(from: protectedReply, key: "Signature"))
+        XCTAssertNil(getHeader(from: protectedReply, key: "Signature-Input"))
+    }
+
+    /// §5 Public Signing API Parity / Message Signature Fail-Open Coverage
+    ///
+    /// signRequest() should apply the same fail-open signing behavior as
+    /// automatic URLSession interception.
+    func testSignRequestMessageSigningFailsOpenWhenSignatureBaseCannotBeBuilt() throws {
+        try reinitializeServiceWithTargetHost()
+
+        let baseParameters = SignatureParameters()
+        _ = baseParameters.addComponentIdentifier("X-Required-Missing")
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory(baseParametersOverride: baseParameters)
+            .setUseAccountMessageSigning()
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+        request.httpMethod = "GET"
+
+        let signedRequest = try ApproovService.signRequest(request)
+
+        XCTAssertNotNil(signedRequest.value(forHTTPHeaderField: "Approov-Token"))
+        XCTAssertNotNil(signedRequest.value(forHTTPHeaderField: "Approov-TraceID"))
+        XCTAssertNil(signedRequest.value(forHTTPHeaderField: "Signature"))
+        XCTAssertNil(signedRequest.value(forHTTPHeaderField: "Signature-Input"))
+
+        let reply = fetchPlainNetworkReply(for: signedRequest)
+        XCTAssertNotNil(reply)
+        XCTAssertNotNil(getHeader(from: reply, key: "Approov-Token"))
+        XCTAssertNil(getHeader(from: reply, key: "Signature"))
+        XCTAssertNil(getHeader(from: reply, key: "Signature-Input"))
+    }
+
+    /// §5 Message Signature Fail-Closed Boundaries
+    ///
+    /// Required body digest generation is a policy error and must fail closed
+    /// when no repeatable body is available.
+    func testRequiredBodyDigestFailureFailsClosed() throws {
+        try reinitializeServiceWithTargetHost()
+
+        let factory = try ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning()
+            .setBodyDigestConfig(ApproovDefaultMessageSigning.DIGEST_SHA256, required: true)
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+        request.httpMethod = "POST"
+
+        let response = ApproovService.updateRequestWithApproov(request: request, sessionConfig: nil)
+
+        XCTAssertEqual(response.decision, .ShouldFail)
+        guard case let ApproovError.permanentError(message)? = response.error else {
+            return XCTFail("Expected permanentError, got \(String(describing: response.error))")
+        }
+        XCTAssertTrue(message.contains("Failed to create required body digest"), "Unexpected message: \(message)")
+        XCTAssertThrowsError(try ApproovService.signRequest(request))
+    }
+
+    /// §5 Message Signature Fail-Closed Boundaries
+    ///
+    /// Unsupported signing algorithms are developer configuration errors and
+    /// must fail closed instead of being swallowed by the fail-open signing
+    /// fallback.
+    func testUnsupportedSigningAlgorithmFailsClosed() throws {
+        try reinitializeServiceWithTargetHost()
+
+        let factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setAlgorithmOverrideForTesting("unsupported")
+        let signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+        ApproovService.setServiceMutator(signer)
+
+        var request = URLRequest(url: try XCTUnwrap(URL(string: targetURLString)))
+        request.httpMethod = "GET"
+
+        let response = ApproovService.updateRequestWithApproov(request: request, sessionConfig: nil)
+
+        XCTAssertEqual(response.decision, .ShouldFail)
+        guard case let ApproovError.permanentError(message)? = response.error else {
+            return XCTFail("Expected permanentError, got \(String(describing: response.error))")
+        }
+        XCTAssertTrue(message.contains("Unsupported algorithm identifier"), "Unexpected message: \(message)")
+        XCTAssertThrowsError(try ApproovService.signRequest(request))
+    }
+
     /// §5 Digest Body Application
     ///
     /// The digest body (Content-Digest) for an install message signature is present
@@ -963,6 +1119,33 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
         let response2 = ApproovService.updateRequestWithApproov(request: request, sessionConfig: nil)
         XCTAssertEqual(response2.decision, .ShouldProceed)
         XCTAssertEqual(response2.sdkMessage, "success")
+    }
+
+    // MARK: - §8 Version Telemetry & Release Versioning
+    // TESTING_REQUIREMENTS.md §8
+
+    /// §8 Versioned Service-Layer Telemetry / Development Placeholder
+    ///
+    /// Non-empty initialization should report the service layer name and current
+    /// development placeholder version to the native SDK user-property.
+    func testProtectedInitializationReportsVersionedUserProperty() throws {
+        XCTAssertEqual(MiniSDKAttesterProxyController.userProperty(), "approov-service-urlsession/dev")
+    }
+
+    /// §8 Versioned Service-Layer Telemetry
+    ///
+    /// Empty-config bypass mode must not report protected-service telemetry
+    /// because the native SDK is not initialized for that service layer setup.
+    func testEmptyConfigInitializationDoesNotReportProtectedTelemetry() throws {
+        MiniSDKAttesterProxyController.clearUserProperty()
+        ApproovService.resetForTesting()
+        ApproovService.setLoggingLevel(.off)
+
+        try ApproovService.initialize(config: "", comment: "reinit-empty-config")
+
+        XCTAssertTrue(ApproovService.isInitialized())
+        XCTAssertFalse(ApproovService.isApproovEnabled())
+        XCTAssertNil(MiniSDKAttesterProxyController.userProperty())
     }
 
     // MARK: - Test Helpers


### PR DESCRIPTION
## Summary
Validates the URLSession service layer against `core-service-layers-testing/TESTING_REQUIREMENTS.md` (main) and addresses the message-signing fail-open policy (core-project-approov#564), version telemetry, and automatic release tagging.

## Message signing — fail-open (#564)
The layer's known #564 gap was confirmed and fixed:
- ES256 **ASN.1/DER decode failure** → now logs at error and proceeds **unsigned** (was fail-closed/throwing).
- **Signature / Signature-Input serialization failure** → now fails open (was fail-closed).
- The ES256 ASN.1/DER decoder is now **bounds-checked** (0-based, guarded reads) so a malformed/truncated signature **throws** (and fails open) instead of risking an out-of-bounds trap that no `do/catch` could recover.
- Preserved fail-closed: a **required body digest** that cannot be generated, and an **unsupported algorithm**.

## Version telemetry + automatic tagging (SwiftPM + CocoaPods)
- `setUserProperty` now reports `approov-service-urlsession/<version>` (was version-less).
- `Package.swift` `releaseTAG`, `ApproovURLSession.podspec` `s.version`, and the user-property string are now `dev` placeholders.
- New `tag-release` job (`build_and_test.yml`, main only, `needs: build-and-test`): the top CHANGELOG entry drives the git tag and the version is stamped in lock-step into both manifests + the user-property before the release commit is tagged. `main` keeps `dev`; each tag carries the stamped version. Skipped if the tag exists.

## Initializer (verified conformant — no change needed)
- Empty config → bypass mode, native SDK not initialized.
- Empty-then-valid upgrade allowed; valid-then-empty ignored (state preserved).
- `comment`/`options:` forwarded verbatim to the native SDK initialize.
- Same-config re-init relies on the native SDK boolean; the Swift/ObjC `BOOL=NO` → `Foundation._GenericObjCError` code 0 bridging artifact is treated as "already initialized" (success), while a genuine different-config error still surfaces as failure.
- State only mutated on SDK success; service mutator reset to default on success.

## Validation
Full suite passes with the mini-SDK: **35 tests, 0 failures** (incl. install/account message-signing and `signRequest`). Clean `swift build`. Broader TESTING_REQUIREMENTS conformance (pinning bypass `.performDefaultHandling`, default mutator fail-closed set, byte-sequence Signature encoding, token binding, exclusion/substitution, common interface) verified.