### PR TITLE
test: fix testProtectedInitializationReportsVersionedUserProperty after version bootstrap

### DIFF
--- a/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
+++ b/Tests/ApproovURLSessionMiniSDKTests/ApproovServiceMiniSDKTests.swift
@@ -1132,16 +1132,22 @@ final class ApproovServiceMiniSDKTests: XCTestCase {
     // MARK: - §8 Version Telemetry & Release Versioning
     // TESTING_REQUIREMENTS.md §8
 
-    /// §8 Versioned Service-Layer Telemetry / Development Placeholder
+    /// §8 Versioned Service-Layer Telemetry
     ///
-    /// Non-empty initialization should report the service layer name and current
-    /// development placeholder version to the native SDK user-property.
+    /// Non-empty initialization should report the service layer name together with
+    /// a concrete x.y.z version to the native SDK user-property (not a bare,
+    /// version-less string). The exact version is stamped per release, so this
+    /// asserts the format rather than a fixed value.
     func testProtectedInitializationReportsVersionedUserProperty() throws {
         try reinitializeServiceWithTargetHost()
         let token = try ApproovService.fetchToken(url: targetURLString)
         let payload = try XCTUnwrap(decodeJWTBody(token))
 
-        XCTAssertEqual(payload["user_property"] as? String, "approov-service-urlsession/dev")
+        let userProperty = try XCTUnwrap(payload["user_property"] as? String)
+        XCTAssertNotNil(
+            userProperty.range(of: #"^approov-service-urlsession/\d+\.\d+\.\d+$"#, options: .regularExpression),
+            "Expected a versioned user-property 'approov-service-urlsession/<x.y.z>', got '\(userProperty)'"
+        )
     }
 
     // MARK: - Test Helpers


### PR DESCRIPTION
## Why
After #54, `main` carries a real `x.y.z` version (`3.5.10`) in the telemetry user-property instead of the `dev` placeholder, and the release workflow stamps the CHANGELOG version per release. The test `testProtectedInitializationReportsVersionedUserProperty` asserted the literal `approov-service-urlsession/dev`, so it failed on `main`.

## Fix
Assert the **format** `approov-service-urlsession/<x.y.z>` via regex rather than a fixed value. This:
- unbreaks `main`,
- stays green across every future release (no per-release test edit), and
- still enforces §8's intent — the property is versioned, not the old bare, version-less string.

Verified the regex matches `3.5.10`/`3.5.11` and rejects `dev` and the bare prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)