### PR TITLE
ci(release): push to protected main via RELEASE_TOKEN bypass actor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,14 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # main is a protected branch (PRs required). The default GITHUB_TOKEN /
+          # github-actions[bot] is NOT a bypass actor, so its push is rejected.
+          # RELEASE_TOKEN must be a token whose actor IS a bypass actor on the
+          # branch ruleset (a fine-grained PAT with contents:write, or a GitHub
+          # App installation token). persist-credentials wires it into git so the
+          # commit + tag pushes below authenticate as that bypassing actor.
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: true
 
       - name: Read and validate version from CHANGELOG
         id: get-version


### PR DESCRIPTION
## Why
The first run of **Release Current Main Branch** failed:

> remote: error: GH006: Protected branch update failed for refs/heads/main.
> remote: - Changes must be made through a pull request.

`main` is now protected (PRs required). The release job stamps the version and pushes a `Release version x.y.z` commit to `main`, but the default `GITHUB_TOKEN` (`github-actions[bot]`) is not a bypass actor, so the push is rejected.

## Change
Check out with a dedicated `RELEASE_TOKEN` and `persist-credentials: true`, so the release commit + tag pushes authenticate as a bypassing actor instead of `github-actions[bot]`.

## Required one-time admin setup (before re-running the release)
1. **Create `RELEASE_TOKEN`** repo secret — a fine-grained PAT with `contents: write` on this repo (or a GitHub App installation token).
2. **Add that actor to the bypass list** of the `main` branch ruleset (the user behind the PAT, or the GitHub App).

Without both, the release push will still be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)