### PR TITLE
ci(release): tag-only release — no push to protected main, no token needed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -205,11 +205,11 @@ jobs:
   #   - that top version is NOT already tagged (forces a new CHANGELOG entry
   #     after each release before more release changes land); and
   #   - Package.swift releaseTAG, every root .podspec s.version, and the
-  #     approov-service-urlsession/<version> telemetry string each carry a valid
-  #     x.y.z version and agree with each other.
+  #     approov-service-urlsession/<version> telemetry string each carry that
+  #     same top CHANGELOG version (so main is always ready to tag).
   # Tagging is a SEPARATE, manual step: the "Release Current Main Branch"
-  # workflow (release.yml) reads the top CHANGELOG version, stamps it into those
-  # three locations, commits to main and tags that commit.
+  # workflow (release.yml) only verifies and tags main's HEAD — it never pushes
+  # a commit to main, so the version is bumped here via PR, not by CI.
   # ---------------------------------------------------------------------------
   verify-release:
     runs-on: ubuntu-latest
@@ -236,11 +236,15 @@ jobs:
             fail=1
           fi
 
-          # Version carried by each source location (must be a real x.y.z, not a placeholder).
+          # Every source location must carry exactly the top CHANGELOG version, so main is
+          # always ready for the release job to tag.
           PKG=$(grep -m1 -oE "releaseTAG[[:space:]]*=[[:space:]]*\"$SEMVER\"" Package.swift | grep -oE "$SEMVER") || true
           if [ -z "$PKG" ]; then
             echo "::error::Package.swift releaseTAG must be an x.y.z version"
             grep -nE 'releaseTAG[[:space:]]*=' Package.swift || true
+            fail=1
+          elif [ "$PKG" != "$VERSION" ]; then
+            echo "::error::Package.swift releaseTAG ($PKG) must match the top CHANGELOG version ($VERSION)"
             fail=1
           fi
 
@@ -250,9 +254,11 @@ jobs:
             echo "::error::$SRC must report approov-service-urlsession/<x.y.z>"
             grep -nE 'setUserProperty' "$SRC" || true
             fail=1
+          elif [ "$TEL" != "$VERSION" ]; then
+            echo "::error::telemetry version ($TEL) must match the top CHANGELOG version ($VERSION)"
+            fail=1
           fi
 
-          # Every version-bearing location must agree with the others.
           for p in *.podspec; do
             [ -e "$p" ] || continue
             POD=$(grep -m1 -oE "\.version[[:space:]]*=[[:space:]]*\"$SEMVER\"" "$p" | grep -oE "$SEMVER") || true
@@ -260,16 +266,11 @@ jobs:
               echo "::error::$p s.version must be an x.y.z version"
               grep -nE '\.version[[:space:]]*=' "$p" || true
               fail=1
-            elif [ -n "$PKG" ] && [ "$POD" != "$PKG" ]; then
-              echo "::error::$p s.version ($POD) does not match Package.swift releaseTAG ($PKG)"
+            elif [ "$POD" != "$VERSION" ]; then
+              echo "::error::$p s.version ($POD) must match the top CHANGELOG version ($VERSION)"
               fail=1
             fi
           done
-
-          if [ -n "$PKG" ] && [ -n "$TEL" ] && [ "$TEL" != "$PKG" ]; then
-            echo "::error::telemetry version ($TEL) does not match Package.swift releaseTAG ($PKG)"
-            fail=1
-          fi
 
           if [ "$fail" -ne 0 ]; then
             echo "::error::Release verification failed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,20 +3,20 @@ name: Release Current Main Branch
 # Manual release (workflow_dispatch ONLY — the single place that tags).
 #
 # Run this from the Actions tab against main once main is known good (code is
-# already built and tested on every push). It:
+# already built and tested on every push). It NEVER pushes a commit to the
+# protected main branch — it only creates a tag, so the default GITHUB_TOKEN is
+# enough (no PAT / ruleset bypass required). It:
 #   1. reads the top CHANGELOG version (## [x.y.z]);
 #   2. refuses to proceed if that version is already tagged (i.e. someone forgot
 #      to add a new CHANGELOG entry for this release);
-#   3. overwrites the x.y.z version carried in lock-step by Package.swift
-#      (releaseTAG), every root .podspec (s.version) and the
-#      approov-service-urlsession/<version> telemetry string with the CHANGELOG
-#      version;
-#   4. commits the change to main (only if anything actually changed); and
-#   5. tags that commit and pushes the tag.
+#   3. verifies main already carries that exact version in lock-step in
+#      Package.swift (releaseTAG), every root .podspec (s.version) and the
+#      approov-service-urlsession/<version> telemetry string — the version is
+#      bumped beforehand via a normal PR, not by CI; and
+#   4. tags main's HEAD with the version and pushes the tag.
 #
 # Because the tag points at main's HEAD, the released commit always belongs to a
-# branch (no orphan-commit banner). main is left carrying the just-released
-# version as its "last released" marker for the next cycle.
+# branch (no orphan-commit banner).
 
 on:
   workflow_dispatch:
@@ -35,11 +35,11 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Read and validate version from CHANGELOG
-        id: get-version
+      - name: Validate version and tag main
         run: |
           set -uo pipefail
           SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
+          SRC="Sources/ApproovURLSession/ApproovService.swift"
 
           VERSION=$(grep -m1 -oE "^## \[$SEMVER\]" CHANGELOG.md | grep -oE "$SEMVER") || true
           if [ -z "$VERSION" ]; then
@@ -53,48 +53,23 @@ jobs:
             exit 1
           fi
 
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Releasing version $VERSION"
-
-      - name: Stamp version, commit and tag main
-        run: |
-          set -uo pipefail
-          VERSION="${{ steps.get-version.outputs.VERSION }}"
-          SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
-          SRC="Sources/ApproovURLSession/ApproovService.swift"
-
-          # Overwrite the existing x.y.z version in each location with the CHANGELOG version.
-          # Each substitution is anchored so it never touches unrelated versions
-          # (e.g. Package.swift's sdkVersion).
-          perl -pi -e "s|approov-service-urlsession/$SEMVER|approov-service-urlsession/$VERSION|g" "$SRC"
-          perl -pi -e "s|(releaseTAG\s*=\s*\")$SEMVER(\")|\${1}$VERSION\${2}|g" Package.swift
-          for PODSPEC in *.podspec; do
-            [ -e "$PODSPEC" ] || continue
-            perl -pi -e "s|(\bs(?:pec)?\.version\s*=\s*['\"])$SEMVER(['\"])|\${1}$VERSION\${2}|g" "$PODSPEC"
-          done
-
-          # Defensive: every location must now carry exactly $VERSION.
+          # main must already carry $VERSION in all three locations (bumped via PR
+          # before releasing). This job only tags — it never pushes to main.
           fail=0
           grep -qE "releaseTAG[[:space:]]*=[[:space:]]*\"$VERSION\"" Package.swift \
-            || { echo "::error::Package.swift releaseTAG was not stamped to $VERSION"; fail=1; }
+            || { echo "::error::Package.swift releaseTAG is not $VERSION"; fail=1; }
           grep -qF "approov-service-urlsession/$VERSION" "$SRC" \
-            || { echo "::error::$SRC telemetry was not stamped to $VERSION"; fail=1; }
+            || { echo "::error::$SRC telemetry is not approov-service-urlsession/$VERSION"; fail=1; }
           for PODSPEC in *.podspec; do
             [ -e "$PODSPEC" ] || continue
             grep -qE "\.version[[:space:]]*=[[:space:]]*\"$VERSION\"" "$PODSPEC" \
-              || { echo "::error::$PODSPEC s.version was not stamped to $VERSION"; fail=1; }
+              || { echo "::error::$PODSPEC s.version is not $VERSION"; fail=1; }
           done
-          [ "$fail" -eq 0 ] || exit 1
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git diff --quiet; then
-            echo "Source already at $VERSION; tagging current main HEAD."
-          else
-            git commit -am "Release version $VERSION"
-            git push origin main
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::main is not stamped to $VERSION. Open a PR bumping Package.swift releaseTAG, every *.podspec s.version and the telemetry string to $VERSION (matching the top CHANGELOG entry), merge it, then re-run this release."
+            exit 1
           fi
 
           git tag "$VERSION"
           git push origin "$VERSION"
+          echo "Tagged main @ $(git rev-parse --short HEAD) as $VERSION"

--- a/ApproovURLSession.podspec
+++ b/ApproovURLSession.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name         = "ApproovURLSession"
-  # The released version on main this commit descends from — overwritten with the top CHANGELOG
-  # version by the "Release Current Main Branch" CI job at release time (in lock-step with
-  # Package.swift releaseTAG and the runtime user-property string).
-  s.version      = "3.5.10"
+  # The version main is at — must match the top CHANGELOG entry, in lock-step with Package.swift
+  # releaseTAG and the runtime user-property string. Bump all three in a PR; the "Release Current
+  # Main Branch" CI job then tags main at this version.
+  s.version      = "3.5.11"
   s.summary      = "Approov mobile attestation SDK"
   s.description  = <<-DESC
     Approov SDK integrates security attestation and secure string fetching for both iOS and watchOS apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ## [3.5.11] - 2026-06-24
 
 ### Added
-- Manual release via the dedicated **Release Current Main Branch** workflow (`release.yml`, `workflow_dispatch`): it reads the top CHANGELOG version, refuses to proceed if that version is already tagged (a forgotten CHANGELOG bump), then overwrites the `x.y.z` version held in lock-step by `Package.swift` (`releaseTAG`), the CocoaPods `ApproovURLSession.podspec` (`s.version`) and the runtime user-property string, commits to `main` and tags that commit. The tag points at `main`'s HEAD, so the released commit always belongs to a branch. `main` now carries the last released version (a real `x.y.z`) rather than a `dev` placeholder.
+- Manual release via the dedicated **Release Current Main Branch** workflow (`release.yml`, `workflow_dispatch`): it reads the top CHANGELOG version, refuses to proceed if that version is already tagged (a forgotten CHANGELOG bump), verifies `main` already carries that version in lock-step in `Package.swift` (`releaseTAG`), the CocoaPods `ApproovURLSession.podspec` (`s.version`) and the runtime user-property string, then tags `main`'s HEAD and pushes the tag. It never pushes a commit to `main` (no token/ruleset bypass needed) and the tag points at a `main` commit, so the released commit always belongs to a branch. The version is bumped beforehand via a normal PR; `verify-release` enforces that these three locations match the top CHANGELOG entry. `main` now carries a real `x.y.z` rather than a `dev` placeholder.
 - The runtime Approov user-property now reports the service-layer version (`approov-service-urlsession/<version>`); previously a bare, version-less string was reported.
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
 // swift-tools-version:5.8
 import Foundation
 import PackageDescription
-// The released version on main this commit descends from. The "Release Current Main Branch"
-// CI job (release.yml) overwrites this with the top CHANGELOG version at release time and tags
-// that commit, in lock-step with the podspec s.version and the runtime user-property string.
-let releaseTAG = "3.5.10"
+// The version main is at — must match the top CHANGELOG entry, in lock-step with the podspec
+// s.version and the runtime user-property string. Bump all three (and add the CHANGELOG entry)
+// in a PR; the "Release Current Main Branch" CI job (release.yml) then tags main at this version.
+let releaseTAG = "3.5.11"
 // SDK package version (used for both iOS and watchOS)
 let sdkVersion: Version = "3.5.3"
 let useMiniSDK = ProcessInfo.processInfo.environment["APPROOV_USE_MINI_SDK"] == "1"

--- a/Sources/ApproovURLSession/ApproovService.swift
+++ b/Sources/ApproovURLSession/ApproovService.swift
@@ -258,9 +258,9 @@ public class ApproovService {
             }
             serviceIsInitialized = true
             if !config.isEmpty {
-                // The version here is the last released version on main; the "Release Current Main
-                // Branch" CI job overwrites it with the top CHANGELOG version at release time.
-                Approov.setUserProperty("approov-service-urlsession/3.5.10")
+                // Must match the top CHANGELOG entry (in lock-step with Package.swift releaseTAG
+                // and the podspec s.version); bump all three in a PR before tagging a release.
+                Approov.setUserProperty("approov-service-urlsession/3.5.11")
             }
         }
     }


### PR DESCRIPTION
## Why
The release run failed with `GH006: Changes must be made through a pull request` — `main` is now protected and the auto-stamp job pushed a `Release version x.y.z` commit to it. Rather than give CI a ruleset-bypass token (extra setup + a hole in the protection), this makes the release **tag-only**.

## Change
- **`release.yml`** no longer stamps or commits. It verifies `main` already carries the top CHANGELOG version in `Package.swift` (`releaseTAG`), every `*.podspec` (`s.version`) and the telemetry string, then `git tag`s `main`'s HEAD and pushes **only the tag** using the default `GITHUB_TOKEN`. No PAT, no bypass, no push to `main`. The tag still points at a `main` commit → no orphan-commit banner.
- **`verify-release`** now requires those three locations to equal the top CHANGELOG version, so `main` is always ready to tag. The version bump happens in a PR (this one bumps `3.5.10 → 3.5.11`).

## New release procedure
1. In a PR: add the CHANGELOG entry and bump the three version locations to the same `x.y.z`. `verify-release` enforces they match.
2. Merge to `main`.
3. Run **Release Current Main Branch** → it validates and tags `main`'s HEAD.

## Verified locally
Both workflows are valid YAML; `verify-release` passes with all three at `3.5.11`; the release job would tag `3.5.11` at `main` HEAD; `sdkVersion` (`3.5.3`) is untouched.

Supersedes #56 (the RELEASE_TOKEN/bypass approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)